### PR TITLE
NVIDIA: NvDisplayControllerDxe: fix allocated framebuffer size

### DIFF
--- a/Silicon/NVIDIA/Drivers/NvDisplayControllerDxe/NvDisplayControllerDxe.c
+++ b/Silicon/NVIDIA/Drivers/NvDisplayControllerDxe/NvDisplayControllerDxe.c
@@ -416,7 +416,7 @@ CreateFramebufferResource (
 {
   EFI_STATUS    Status;
   VOID          *Address;
-  UINTN         Size, Pages;
+  UINTN         Pitch, Size, Pages;
 
   /* The GOP driver treats bits [25:0] as non-address bits and masks
      them away. Require 64 MB alignment (2^26 B) to make sure the
@@ -426,7 +426,14 @@ CreateFramebufferResource (
 
   ZeroMem (Desc, sizeof (*Desc));
 
-  Size = HorizontalResolution * VerticalResolution * PixelSize;
+  /* Calculate pitch as the size of a framebuffer row, rounded up to
+     the next power of two. */
+  Pitch = HorizontalResolution * PixelSize;
+  if ((Pitch & -Pitch) != Pitch) {
+    Pitch = (UINTN) GetPowerOfTwo32 ((UINT32) Pitch) << 1;
+  }
+
+  Size = VerticalResolution * Pitch;
   /* Since we are allocating the framebuffer memory as
      EfiRuntimeServicesData, make sure the size is a multiple of
      RUNTIME_PAGE_ALLOCATION_GRANULARITY in order to avoid problems


### PR DESCRIPTION
Correct the framebuffer size calculation to properly support 4K displays in UEFI.

This fix solves known bootloader issue 3581719 as disclosed in [NVIDIA Jetson Linux 34.1](https://developer.nvidia.com/embedded/jetson-linux-r341) Release Notes.