### PR TITLE
fix: t234: clean invalidate caches to scf level using mce ari

### DIFF
--- a/Platform/NVIDIA/Jetson/Jetson.dsc.inc
+++ b/Platform/NVIDIA/Jetson/Jetson.dsc.inc
@@ -27,8 +27,6 @@
 !include Platform/NVIDIA/NVIDIA.common.dsc.inc
 
 [LibraryClasses.common]
-  CacheMaintenanceLib|Silicon/NVIDIA/Library/TegraCacheMaintenanceLib/TegraCacheMaintenanceLib.inf
-
   TegraCombinedSerialPortLib|Silicon/NVIDIA/Library/TegraCombinedSerialPort/TegraCombinedSerialPortLib.inf
   Tegra16550SerialPortLib|Silicon/NVIDIA/Library/Tegra16550SerialPortLib/Tegra16550SerialPortLib.inf
   TegraSbsaSerialPortLib|Silicon/NVIDIA/Library/TegraSbsaSerialPortLib/TegraSbsaSerialPortLib.inf
@@ -41,6 +39,9 @@
   PciExpressLib|MdePkg/Library/BasePciExpressLib/BasePciExpressLib.inf
 
   AndroidBootImgLib|EmbeddedPkg/Library/AndroidBootImgLib/AndroidBootImgLib.inf
+
+[LibraryClasses.common.UEFI_DRIVER, LibraryClasses.common.UEFI_APPLICATION, LibraryClasses.common.DXE_DRIVER]
+  CacheMaintenanceLib|Silicon/NVIDIA/Library/TegraCacheMaintenanceLib/TegraCacheMaintenanceLib.inf
 
 ################################################################################
 #

--- a/Silicon/NVIDIA/Include/Library/MceAriLib.h
+++ b/Silicon/NVIDIA/Include/Library/MceAriLib.h
@@ -89,4 +89,24 @@ MceAriCoreIsPresent (
   IN  UINTN     CoreId
   );
 
+/**
+  Initiate an SCF level Cache Clean
+
+**/
+VOID
+EFIAPI
+MceAriSCFCacheClean (
+  VOID
+  );
+
+/**
+  Initiate an SCF level Cache Clean Invalidate
+
+**/
+VOID
+EFIAPI
+MceAriSCFCacheCleanInvalidate (
+  VOID
+  );
+
 #endif

--- a/Silicon/NVIDIA/Include/Library/TegraPlatformInfoLib.h
+++ b/Silicon/NVIDIA/Include/Library/TegraPlatformInfoLib.h
@@ -1,6 +1,6 @@
 /** @file
 *
-*  Copyright (c) 2019-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+*  Copyright (c) 2019-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 *
 *  SPDX-License-Identifier: BSD-2-Clause-Patent
 *
@@ -11,12 +11,14 @@
 
 #define UEFI_DECLARE_ALIGNED(var, size) var __attribute__ ((aligned (size)))
 
-#define T194_CHIP_ID      0x19
-#define T234_CHIP_ID      0x23
+#define T194_CHIP_ID       0x19
+#define T234_CHIP_ID       0x23
 
-#define T194_SKU          1
-#define T234_SKU          2
-#define T234SLT_SKU       3
+#define T194_SKU           1
+#define T234_SKU           2
+#define T234SLT_SKU        3
+
+#define T234_CHIP_MAJORREV 4
 
 #define SYSIMG_EMMC_MAGIC_OFFSET 0x4
 #define SYSIMG_EMMC_MAGIC 0xEAAAAAAC

--- a/Silicon/NVIDIA/Library/MceAriLib/MceAriLib.c
+++ b/Silicon/NVIDIA/Library/MceAriLib/MceAriLib.c
@@ -24,9 +24,14 @@
 #define TEGRA_ARI_VERSION_MINOR     1
 
 // ARI Request IDs
-#define TEGRA_ARI_VERSION_CMD       0
-#define TEGRA_ARI_ECHO_CMD          1
-#define TEGRA_ARI_NUM_CORES_CMD     2
+#define TEGRA_ARI_VERSION_CMD            0
+#define TEGRA_ARI_ECHO_CMD               1
+#define TEGRA_ARI_NUM_CORES_CMD          2
+#define TEGRA_ARI_CCPLEX_CACHE_OPERATION 97
+
+// ARI Cache Operation IDs
+#define TEGRA_ARI_CCPLEX_CACHE_CLEAN            0
+#define TEGRA_ARI_CCPLEX_CACHE_CLEAN_INVALIDATE 1
 
 // Register offsets for ARI request/results
 #define ARI_REQUEST_OFFS            0x00
@@ -547,4 +552,53 @@ MceAriCoreIsPresent (
   }
 
   return Present;
+}
+
+/**
+  Request specified MCE cache operation.
+
+  @param[in]    AriBase         ARI register aperture base address
+**/
+VOID
+EFIAPI
+AriCacheOperation(
+  IN  UINTN     AriBase,
+  IN  UINT32    OperationCode
+  )
+{
+  if (MceAriSupported ()) {
+    AriRequestWait (AriBase, 0, TEGRA_ARI_CCPLEX_CACHE_OPERATION, OperationCode, 0);
+  }
+}
+
+/**
+  Initiate an SCF level Cache Clean
+
+**/
+VOID
+EFIAPI
+MceAriSCFCacheClean (
+  VOID
+  )
+{
+  UINTN         AriBase;
+
+  AriBase = MceAriGetApertureBase ();
+  AriCacheOperation (AriBase, TEGRA_ARI_CCPLEX_CACHE_CLEAN);
+}
+
+/**
+  Initiate an SCF level Cache Clean Invalidate
+
+**/
+VOID
+EFIAPI
+MceAriSCFCacheCleanInvalidate (
+  VOID
+  )
+{
+  UINTN         AriBase;
+
+  AriBase = MceAriGetApertureBase ();
+  AriCacheOperation (AriBase, TEGRA_ARI_CCPLEX_CACHE_CLEAN_INVALIDATE);
 }

--- a/Silicon/NVIDIA/Library/TegraCacheMaintenanceLib/TegraCacheMaintenanceLib.c
+++ b/Silicon/NVIDIA/Library/TegraCacheMaintenanceLib/TegraCacheMaintenanceLib.c
@@ -11,6 +11,8 @@
 #include <Library/ArmLib.h>
 #include <Library/DebugLib.h>
 #include <Library/PcdLib.h>
+#include <Library/TegraPlatformInfoLib.h>
+#include <Library/MceAriLib.h>
 
 STATIC
 VOID
@@ -35,6 +37,13 @@ CacheRangeOperation (
     LineOperation(AlignedAddress);
     AlignedAddress += LineLength;
   }
+
+  if (TegraGetPlatform () != TEGRA_PLATFORM_VDK &&
+      TegraGetChipID () == T234_CHIP_ID &&
+      TegraGetMajorVersion () == T234_CHIP_MAJORREV) {
+    MceAriSCFCacheCleanInvalidate ();
+  }
+
   ArmDataSynchronizationBarrier ();
 }
 
@@ -65,7 +74,9 @@ InvalidateInstructionCacheRange (
 {
   CacheRangeOperation (Address, Length, ArmCleanDataCacheEntryToPoUByMVA,
     ArmDataCacheLineLength ());
-  ArmInvalidateInstructionCache ();
+  CacheRangeOperation (Address, Length,
+    ArmInvalidateInstructionCacheEntryToPoUByMVA,
+    ArmInstructionCacheLineLength ());
 
   ArmInstructionSynchronizationBarrier ();
 

--- a/Silicon/NVIDIA/Library/TegraCacheMaintenanceLib/TegraCacheMaintenanceLib.inf
+++ b/Silicon/NVIDIA/Library/TegraCacheMaintenanceLib/TegraCacheMaintenanceLib.inf
@@ -23,7 +23,9 @@
 [Packages]
   ArmPkg/ArmPkg.dec
   MdePkg/MdePkg.dec
+  Silicon/NVIDIA/NVIDIA.dec
 
 [LibraryClasses]
   ArmLib
   BaseLib
+  MceAriLib


### PR DESCRIPTION
Arm cache maintenance api may not be able to reach SCF. Rely on
explicit mce ari calls.

Change-Id: I96da9a8e4649299045a467fcd05f85eed289d678
Reviewed-on: https://git-master.nvidia.com/r/c/tegra/bootloader/uefi/edk2-nvidia/+/2709823
Reviewed-by: svc-sw-mobile-l4t <svc-sw-mobile-l4t@nvidia.com>
Reviewed-by: Ashish Singhal <ashishsingha@nvidia.com>
Tested-by: Ashish Singhal <ashishsingha@nvidia.com>
GVS: Gerrit_Virtual_Submit