### PR TITLE
fix(eqos): EQoS DMA may be active at exit boot services 

### DIFF
--- a/Silicon/NVIDIA/Drivers/EqosDeviceDxe/EqosDeviceDxe.c
+++ b/Silicon/NVIDIA/Drivers/EqosDeviceDxe/EqosDeviceDxe.c
@@ -111,6 +111,8 @@ OnExitBootServices (
     }
   }
 
+  SnpShutdown (&Snp->Snp);
+
   return;
 }
 


### PR DESCRIPTION
Need to shutdown network activity at UEFI exit especially in the case of ACPI boot.
As the memory set aside for that may be reclaimed by operating system.

Bug 3680336

Signed-off-by: Jeff Brasen <jbrasen@nvidia.com>
Change-Id: I834741497e32d074af53a146921a031eb8dcd8e1
Reviewed-on: https://git-master.nvidia.com/r/c/tegra/bootloader/uefi/edk2-nvidia/+/2728620
Reviewed-by: svcacv <svcacv@nvidia.com>
Reviewed-by: svc-sw-mobile-l4t <svc-sw-mobile-l4t@nvidia.com>
Reviewed-by: Ashish Singhal <ashishsingha@nvidia.com>
GVS: Gerrit_Virtual_Submit