### PR TITLE
fix: Calculate redist size dynamically

### DIFF
--- a/Silicon/NVIDIA/Library/ConfigurationManagerLib/ConfigurationManagerLib.inf
+++ b/Silicon/NVIDIA/Library/ConfigurationManagerLib/ConfigurationManagerLib.inf
@@ -24,6 +24,7 @@
   DeviceTreeHelperLib
   MemoryAllocationLib
   FdtLib
+  IoLib
   PlatformResourceLib
   FloorSweepingInternalLib
   UefiLib


### PR DESCRIPTION
Add support for walking the GICR to find size.

Bug 3750428

Signed-off-by: Jeff Brasen <jbrasen@nvidia.com>
Change-Id: Iebbaba7948e8f82eb8c7edb290b0d46fd4273c7c
Reviewed-on: https://git-master.nvidia.com/r/c/tegra/bootloader/uefi/edk2-nvidia/+/2758675
Reviewed-by: svcacv <svcacv@nvidia.com>
Reviewed-by: Swatisri Kantamsetti <swatisrik@nvidia.com>
Reviewed-by: Ashish Singhal <ashishsingha@nvidia.com>
Tested-by: Rohit Khanna <rokhanna@nvidia.com>
GVS: Gerrit_Virtual_Submit