### PR TITLE
feat: Variable based default boot order support

### DIFF
--- a/Silicon/NVIDIA/Drivers/DefaultVariableDxe/DefaultVariableDxe.inf
+++ b/Silicon/NVIDIA/Drivers/DefaultVariableDxe/DefaultVariableDxe.inf
@@ -50,6 +50,7 @@
   gNVIDIAPublicVariableGuid
   gEfiGlobalVariableGuid
   gDtPlatformFormSetGuid
+  gNVIDIATokenSpaceGuid
   gEfiPartTypeSystemPartGuid
 
 [Protocols]

--- a/Silicon/NVIDIA/Library/PlatformBootOrderLib/PlatformBootOrderLib.c
+++ b/Silicon/NVIDIA/Library/PlatformBootOrderLib/PlatformBootOrderLib.c
@@ -15,181 +15,127 @@
 #include <Library/UefiLib.h>
 #include <Library/UefiRuntimeServicesTableLib.h>
 #include <Library/DevicePathLib.h>
+#include <Library/SortLib.h>
+#include <Library/DebugLib.h>
 
+#define NVIDIA_BOOT_TYPE_HTTP     0
+#define NVIDIA_BOOT_TYPE_BOOTIMG  1
 
-UINT8 RemovableReversePriorityBootOrder[] = {
-  MSG_SD_DP,
-  MSG_USB_DP
+typedef struct {
+  CHAR8    *OrderName;
+  INT32    PriorityOrder;
+  UINT8    Type;
+  UINT8    SubType;
+  UINT8    ExtraSpecifier;
+} NVIDIA_BOOT_ORDER_PRIORITY;
+
+STATIC NVIDIA_BOOT_ORDER_PRIORITY  mBootPriority[] = {
+  { "scsi",     MAX_INT32, MESSAGING_DEVICE_PATH, MSG_SCSI_DP,           MAX_UINT8                },
+  { "usb",      MAX_INT32, MESSAGING_DEVICE_PATH, MSG_USB_DP,            MAX_UINT8                },
+  { "sata",     MAX_INT32, MESSAGING_DEVICE_PATH, MSG_SATA_DP,           MAX_UINT8                },
+  { "pxev4",    MAX_INT32, MESSAGING_DEVICE_PATH, MSG_IPv4_DP,           MAX_UINT8                },
+  { "httpv4",   MAX_INT32, MESSAGING_DEVICE_PATH, MSG_IPv4_DP,           NVIDIA_BOOT_TYPE_HTTP    },
+  { "pxev6",    MAX_INT32, MESSAGING_DEVICE_PATH, MSG_IPv6_DP,           MAX_UINT8                },
+  { "httpv6",   MAX_INT32, MESSAGING_DEVICE_PATH, MSG_IPv6_DP,           NVIDIA_BOOT_TYPE_HTTP    },
+  { "nvme",     MAX_INT32, MESSAGING_DEVICE_PATH, MSG_NVME_NAMESPACE_DP, MAX_UINT8                },
+  { "ufs",      MAX_INT32, MESSAGING_DEVICE_PATH, MSG_UFS_DP,            MAX_UINT8                },
+  { "sd",       MAX_INT32, MESSAGING_DEVICE_PATH, MSG_SD_DP,             MAX_UINT8                },
+  { "emmc",     MAX_INT32, MESSAGING_DEVICE_PATH, MSG_EMMC_DP,           MAX_UINT8                },
+  { "cdrom",    MAX_INT32, MEDIA_DEVICE_PATH,     MEDIA_CDROM_DP,        MAX_UINT8                },
+  { "boot.img", MAX_INT32, MAX_UINT8,             MAX_UINT8,             NVIDIA_BOOT_TYPE_BOOTIMG },
 };
 
+#define DEFAULT_BOOT_ORDER_STRING  "boot.img,usb,sd,emmc,ufs"
 
-UINT8 NonRemovableReversePriorityBootOrder[] = {
-  MSG_UFS_DP,
-  MSG_EMMC_DP
-};
-
-
-VOID
+STATIC
+INT32
 EFIAPI
-SetMediaBootPriority (
-  IN UINT8 DeviceSubType
+GetDevicePriority (
+  IN UINT16  BootOption
   )
 {
-  EFI_STATUS                   Status;
-  UINT16                       *BootOrder;
-  UINTN                        BootOrderSize;
-  UINT16                       *NewOrder;
-  UINT16                       *RemainBoots;
-  UINTN                        SelectCnt;
-  UINTN                        RemainCnt;
-  UINTN                        Index;
-  BOOLEAN                      NewOrderFound;
-  CHAR16                       OptionName[sizeof ("Boot####")];
-  EFI_BOOT_MANAGER_LOAD_OPTION Option;
-  EFI_DEVICE_PATH_PROTOCOL     *DevicePathNode;
+  EFI_STATUS                    Status;
+  CHAR16                        OptionName[sizeof ("Boot####")];
+  EFI_BOOT_MANAGER_LOAD_OPTION  Option;
+  UINTN                         OptionalDataSize;
+  UINTN                         BootPriorityIndex;
+  EFI_DEVICE_PATH_PROTOCOL      *DevicePathNode;
+  UINT8                         ExtraSpecifier;
 
-  GetEfiGlobalVariable2 (L"BootOrder", (VOID **) &BootOrder, &BootOrderSize);
-  if (BootOrder == NULL) {
-    return;
+  UnicodeSPrint (OptionName, sizeof (OptionName), L"Boot%04x", BootOption);
+  Status = EfiBootManagerVariableToLoadOption (OptionName, &Option);
+  if (EFI_ERROR (Status)) {
+    return MAX_INT32;
   }
 
-  NewOrder = AllocatePool (BootOrderSize);
-  RemainBoots = AllocatePool (BootOrderSize);
-  if ((NewOrder == NULL) || (RemainBoots == NULL)) {
-    goto Exit;
+  OptionalDataSize = 0;
+  if (Option.OptionalData != NULL) {
+    OptionalDataSize = StrSize ((CONST CHAR16 *)Option.OptionalData);
   }
 
-  SelectCnt = 0;
-  RemainCnt = 0;
-
-  for (Index = 0; Index < BootOrderSize / sizeof (UINT16); Index++) {
-    NewOrderFound = FALSE;
-    UnicodeSPrint (OptionName, sizeof (OptionName), L"Boot%04x", BootOrder[Index]);
-    Status = EfiBootManagerVariableToLoadOption (OptionName, &Option);
-    if (EFI_ERROR (Status)) {
-      continue;
-    }
-
-    DevicePathNode = Option.FilePath;
-    while (!IsDevicePathEndType (DevicePathNode)) {
-      if ((DevicePathType (DevicePathNode) == MESSAGING_DEVICE_PATH) &&
-          (DevicePathSubType (DevicePathNode) == DeviceSubType)) {
-        NewOrder[SelectCnt++] = BootOrder[Index];
-        NewOrderFound = TRUE;
-        break;
-      }
-      DevicePathNode = NextDevicePathNode (DevicePathNode);
-    }
-
-    if (!NewOrderFound) {
-      RemainBoots[RemainCnt++] = BootOrder[Index];
-    }
-  }
-
-  if (SelectCnt != 0) {
-    for (Index = 0; Index < RemainCnt; Index++) {
-      NewOrder[SelectCnt + Index] = RemainBoots[Index];
-    }
-
-    if (CompareMem (NewOrder, BootOrder, BootOrderSize) != 0) {
-      Status = gRT->SetVariable (L"BootOrder", &gEfiGlobalVariableGuid,
-                      EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_RUNTIME_ACCESS | EFI_VARIABLE_NON_VOLATILE,
-                      BootOrderSize, NewOrder);
-      if (EFI_ERROR (Status)) {
-        goto Exit;
+  if ((Option.OptionalData != NULL) &&
+      (Option.OptionalDataSize == OptionalDataSize + sizeof (EFI_GUID)) &&
+      CompareGuid (
+        (EFI_GUID *)((UINT8 *)Option.OptionalData + OptionalDataSize),
+        &gNVIDIABmBootOptionGuid
+        ))
+  {
+    for (BootPriorityIndex = 0; BootPriorityIndex < ARRAY_SIZE (mBootPriority); BootPriorityIndex++) {
+      if (mBootPriority[BootPriorityIndex].ExtraSpecifier == NVIDIA_BOOT_TYPE_BOOTIMG) {
+        DEBUG ((DEBUG_VERBOSE, "Found %s priority to be %d\r\n", ConvertDevicePathToText (Option.FilePath, TRUE, FALSE), mBootPriority[BootPriorityIndex].PriorityOrder));
+        return mBootPriority[BootPriorityIndex].PriorityOrder;
       }
     }
   }
 
-Exit:
-  FreePool (BootOrder);
-  if (NewOrder != NULL) {
-    FreePool (NewOrder);
+  ExtraSpecifier = MAX_UINT8;
+  DevicePathNode = Option.FilePath;
+  while (!IsDevicePathEndType (DevicePathNode)) {
+    if ((DevicePathType (DevicePathNode) == MESSAGING_DEVICE_PATH) &&
+        (DevicePathSubType (DevicePathNode) == MSG_URI_DP))
+    {
+      ExtraSpecifier = NVIDIA_BOOT_TYPE_HTTP;
+      break;
+    }
+
+    DevicePathNode = NextDevicePathNode (DevicePathNode);
   }
-  if (RemainBoots != NULL) {
-    FreePool (RemainBoots);
+
+  DevicePathNode = Option.FilePath;
+  while (!IsDevicePathEndType (DevicePathNode)) {
+    for (BootPriorityIndex = 0; BootPriorityIndex < ARRAY_SIZE (mBootPriority); BootPriorityIndex++) {
+      if ((DevicePathType (DevicePathNode) == mBootPriority[BootPriorityIndex].Type) &&
+          (DevicePathSubType (DevicePathNode) == mBootPriority[BootPriorityIndex].SubType) &&
+          (ExtraSpecifier == mBootPriority[BootPriorityIndex].ExtraSpecifier))
+      {
+        DEBUG ((DEBUG_VERBOSE, "Found %s priority to be %d\r\n", ConvertDevicePathToText (Option.FilePath, TRUE, FALSE), mBootPriority[BootPriorityIndex].PriorityOrder));
+        return mBootPriority[BootPriorityIndex].PriorityOrder;
+      }
+    }
+
+    DevicePathNode = NextDevicePathNode (DevicePathNode);
   }
+
+  DEBUG ((DEBUG_VERBOSE, "Found %s priority to be %d\r\n", ConvertDevicePathToText (Option.FilePath, TRUE, FALSE), MAX_INT32));
+  return MAX_INT32;
 }
 
-
-VOID
+STATIC
+INTN
 EFIAPI
-SetAndroidBootPriority (
-  VOID
+BootOrderSortCompare (
+  IN CONST VOID  *Buffer1,
+  IN CONST VOID  *Buffer2
   )
 {
-  EFI_STATUS                   Status;
-  UINT16                       *BootOrder;
-  UINTN                        BootOrderSize;
-  UINT16                       *NewOrder;
-  UINT16                       *RemainBoots;
-  UINTN                        SelectCnt;
-  UINTN                        RemainCnt;
-  EFI_BOOT_MANAGER_LOAD_OPTION Option;
-  CHAR16                       OptionName[sizeof ("Boot####")];
-  UINTN                        Index;
-  UINTN                        OptionalDataSize;
+  INT32  Priority1;
+  INT32  Priority2;
 
-  GetEfiGlobalVariable2 (L"BootOrder", (VOID **) &BootOrder, &BootOrderSize);
-  if (BootOrder == NULL) {
-    return;
-  }
+  Priority1 = GetDevicePriority (*(UINT16 *)Buffer1);
+  Priority2 = GetDevicePriority (*(UINT16 *)Buffer2);
 
-  NewOrder = AllocatePool (BootOrderSize);
-  RemainBoots = AllocatePool (BootOrderSize);
-  if ((NewOrder == NULL) || (RemainBoots == NULL)) {
-    goto Exit;
-  }
-
-  SelectCnt = 0;
-  RemainCnt = 0;
-
-  for (Index = 0; Index < BootOrderSize / sizeof (UINT16); Index++) {
-    UnicodeSPrint (OptionName, sizeof (OptionName), L"Boot%04x", BootOrder[Index]);
-    Status = EfiBootManagerVariableToLoadOption (OptionName, &Option);
-    if (EFI_ERROR (Status)) {
-      continue;
-    }
-
-    OptionalDataSize = 0;
-    if (Option.OptionalData != NULL) {
-      OptionalDataSize = StrSize ((CONST CHAR16 *)Option.OptionalData);
-    }
-    if (Option.OptionalData == NULL ||
-        Option.OptionalDataSize != OptionalDataSize + sizeof (EFI_GUID) ||
-        !CompareGuid ((EFI_GUID *)((UINT8 *)Option.OptionalData + OptionalDataSize),
-                      &gNVIDIABmBootOptionGuid)) {
-      RemainBoots[RemainCnt++] = BootOrder[Index];
-    } else {
-      NewOrder[SelectCnt++] = BootOrder[Index];
-    }
-  }
-
-  if (SelectCnt != 0) {
-    for (Index = 0; Index < RemainCnt; Index++) {
-      NewOrder[SelectCnt + Index] = RemainBoots[Index];
-    }
-
-    if (CompareMem (NewOrder, BootOrder, BootOrderSize) != 0) {
-      Status = gRT->SetVariable (L"BootOrder", &gEfiGlobalVariableGuid,
-                      EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_RUNTIME_ACCESS | EFI_VARIABLE_NON_VOLATILE,
-                      BootOrderSize, NewOrder);
-      if (EFI_ERROR (Status)) {
-        goto Exit;
-      }
-    }
-  }
-
-Exit:
-  FreePool (BootOrder);
-  if (NewOrder != NULL) {
-    FreePool (NewOrder);
-  }
-  if (RemainBoots != NULL) {
-    FreePool (RemainBoots);
-  }
+  return Priority1 - Priority2;
 }
-
 
 VOID
 EFIAPI
@@ -197,42 +143,108 @@ SetBootOrder (
   VOID
   )
 {
-  EFI_STATUS                   Status;
-  BOOLEAN                      VariableData;
-  UINTN                        VariableSize;
-  UINT32                       VariableAttributes;
-  UINTN                        Count;
+  EFI_STATUS  Status;
+  BOOLEAN     VariableData;
+  UINTN       VariableSize;
+  UINT32      VariableAttributes;
+  UINT16      *BootOrder;
+  UINTN       BootOrderSize;
+  UINT16      *NewOrder;
+  INT32       Priority;
+  CHAR8       *DefaultBootOrder;
+  UINTN       DefaultBootOrderSize;
+  CHAR8       *CurrentBootPriorityStr;
+  CHAR8       *CurrentBootPriorityEnd;
+  UINTN       CurrentBootPriorityLen;
+  UINTN       BootPriorityMatchLen;
+  UINTN       BootPriorityIndex;
 
   VariableData = FALSE;
   VariableSize = sizeof (BOOLEAN);
-  Status = gRT->GetVariable (L"PlatformBootOrderSet", &gNVIDIATokenSpaceGuid,
-                             &VariableAttributes, &VariableSize, (VOID *)&VariableData);
+  Status       = gRT->GetVariable (
+                        L"PlatformBootOrderSet",
+                        &gNVIDIATokenSpaceGuid,
+                        &VariableAttributes,
+                        &VariableSize,
+                        (VOID *)&VariableData
+                        );
   if (!EFI_ERROR (Status) && (VariableSize == sizeof (BOOLEAN))) {
     if (VariableData == TRUE) {
       return;
     }
   }
 
-  for (Count = 0;
-       Count < sizeof (NonRemovableReversePriorityBootOrder) /
-               sizeof (NonRemovableReversePriorityBootOrder[0]);
-       Count++) {
-    SetMediaBootPriority (NonRemovableReversePriorityBootOrder[Count]);
+  Priority = 0;
+  // Process the priority order
+  Status = GetVariable2 (
+             L"DefaultBootPriority",
+             &gNVIDIATokenSpaceGuid,
+             (VOID **)&DefaultBootOrder,
+             &DefaultBootOrderSize
+             );
+  if (EFI_ERROR (Status)) {
+    DefaultBootOrder     = DEFAULT_BOOT_ORDER_STRING;
+    DefaultBootOrderSize = sizeof (DEFAULT_BOOT_ORDER_STRING);
   }
 
-  for (Count = 0;
-       Count < sizeof (RemovableReversePriorityBootOrder) /
-               sizeof (RemovableReversePriorityBootOrder[0]);
-       Count++) {
-    SetMediaBootPriority (RemovableReversePriorityBootOrder[Count]);
+  CurrentBootPriorityStr = DefaultBootOrder;
+  while (CurrentBootPriorityStr < (DefaultBootOrder + DefaultBootOrderSize)) {
+    CurrentBootPriorityEnd = CurrentBootPriorityStr;
+    while (CurrentBootPriorityEnd < (DefaultBootOrder + DefaultBootOrderSize)) {
+      if ((*CurrentBootPriorityEnd == ',') ||
+          (*CurrentBootPriorityEnd == '\0'))
+      {
+        break;
+      }
+
+      CurrentBootPriorityEnd++;
+    }
+
+    CurrentBootPriorityLen = CurrentBootPriorityEnd - CurrentBootPriorityStr;
+
+    for (BootPriorityIndex = 0; BootPriorityIndex < ARRAY_SIZE (mBootPriority); BootPriorityIndex++) {
+      BootPriorityMatchLen = AsciiStrLen (mBootPriority[BootPriorityIndex].OrderName);
+      if ((BootPriorityMatchLen == CurrentBootPriorityLen) &&
+          (CompareMem (CurrentBootPriorityStr, mBootPriority[BootPriorityIndex].OrderName, CurrentBootPriorityLen) == 0))
+      {
+        DEBUG ((DEBUG_INFO, "Setting %a priority to %d\r\n", mBootPriority[BootPriorityIndex].OrderName, Priority));
+        mBootPriority[BootPriorityIndex].PriorityOrder = Priority;
+        Priority++;
+        break;
+      }
+    }
+
+    CurrentBootPriorityStr += CurrentBootPriorityLen + 1;
   }
 
-  SetAndroidBootPriority ();
+  GetEfiGlobalVariable2 (L"BootOrder", (VOID **)&BootOrder, &BootOrderSize);
+  if (BootOrder == NULL) {
+    return;
+  }
+
+  NewOrder = AllocateCopyPool (BootOrderSize, BootOrder);
+  PerformQuickSort (NewOrder, BootOrderSize/sizeof (UINT16), sizeof (UINT16), BootOrderSortCompare);
+  if (CompareMem (NewOrder, BootOrder, BootOrderSize) != 0) {
+    Status = gRT->SetVariable (
+                    L"BootOrder",
+                    &gEfiGlobalVariableGuid,
+                    EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_RUNTIME_ACCESS | EFI_VARIABLE_NON_VOLATILE,
+                    BootOrderSize,
+                    NewOrder
+                    );
+    if (EFI_ERROR (Status)) {
+      return;
+    }
+  }
 
   VariableData = TRUE;
-  gRT->SetVariable (L"PlatformBootOrderSet", &gNVIDIATokenSpaceGuid,
-                    EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_NON_VOLATILE,
-                    sizeof (BOOLEAN), &VariableData);
+  gRT->SetVariable (
+         L"PlatformBootOrderSet",
+         &gNVIDIATokenSpaceGuid,
+         EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_NON_VOLATILE,
+         sizeof (BOOLEAN),
+         &VariableData
+         );
 
   return;
 }

--- a/Silicon/NVIDIA/Library/PlatformBootOrderLib/PlatformBootOrderLib.inf
+++ b/Silicon/NVIDIA/Library/PlatformBootOrderLib/PlatformBootOrderLib.inf
@@ -1,6 +1,6 @@
 #/** @file
 #
-#    Copyright (c) 2020, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#    Copyright (c) 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 #    SPDX-License-Identifier: BSD-2-Clause-Patent
 #
@@ -27,6 +27,8 @@
   BaseMemoryLib
   PrintLib
   UefiBootManagerLib
+  SortLib
+  DebugLib
 
 [Guids]
   gEfiGlobalVariableGuid

--- a/Silicon/NVIDIA/Tegra/DeviceTree/BootOrderNvme.dts
+++ b/Silicon/NVIDIA/Tegra/DeviceTree/BootOrderNvme.dts
@@ -10,7 +10,7 @@
 /plugin/;
 
 / {
-	overlay-name = "UEFI Boot order pxe default";
+	overlay-name = "UEFI Boot order nvme default";
 
 	fragment@0 {
 		target-path = "/";

--- a/Silicon/NVIDIA/Tegra/DeviceTree/BootOrderNvme.dts
+++ b/Silicon/NVIDIA/Tegra/DeviceTree/BootOrderNvme.dts
@@ -1,0 +1,36 @@
+/** @file
+*
+*  Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+*
+*  SPDX-License-Identifier: BSD-2-Clause-Patent
+*
+**/
+
+/dts-v1/;
+/plugin/;
+
+/ {
+	overlay-name = "UEFI Boot order pxe default";
+
+	fragment@0 {
+		target-path = "/";
+		board_config {
+			sw-modules = "uefi";
+		};
+
+		__overlay__ {
+			firmware {
+				uefi {
+					variables {
+						gNVIDIATokenSpaceGuid {
+							DefaultBootPriority {
+								data = "nvme";
+								locked;
+							};
+						};
+					};
+				};
+			};
+		};
+	};
+};

--- a/Silicon/NVIDIA/Tegra/DeviceTree/BootOrderPxe.dts
+++ b/Silicon/NVIDIA/Tegra/DeviceTree/BootOrderPxe.dts
@@ -1,0 +1,36 @@
+/** @file
+*
+*  Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+*
+*  SPDX-License-Identifier: BSD-2-Clause-Patent
+*
+**/
+
+/dts-v1/;
+/plugin/;
+
+/ {
+	overlay-name = "UEFI Boot order pxe default";
+
+	fragment@0 {
+		target-path = "/";
+		board_config {
+			sw-modules = "uefi";
+		};
+
+		__overlay__ {
+			firmware {
+				uefi {
+					variables {
+						gNVIDIATokenSpaceGuid {
+							DefaultBootPriority {
+								data = "pxev4";
+								locked;
+							};
+						};
+					};
+				};
+			};
+		};
+	};
+};

--- a/Silicon/NVIDIA/Tegra/DeviceTree/BootOrderSata.dts
+++ b/Silicon/NVIDIA/Tegra/DeviceTree/BootOrderSata.dts
@@ -1,0 +1,36 @@
+/** @file
+*
+*  Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+*
+*  SPDX-License-Identifier: BSD-2-Clause-Patent
+*
+**/
+
+/dts-v1/;
+/plugin/;
+
+/ {
+	overlay-name = "UEFI Boot order pxe default";
+
+	fragment@0 {
+		target-path = "/";
+		board_config {
+			sw-modules = "uefi";
+		};
+
+		__overlay__ {
+			firmware {
+				uefi {
+					variables {
+						gNVIDIATokenSpaceGuid {
+							DefaultBootPriority {
+								data = "sata";
+								locked;
+							};
+						};
+					};
+				};
+			};
+		};
+	};
+};

--- a/Silicon/NVIDIA/Tegra/DeviceTree/BootOrderUfs.dts
+++ b/Silicon/NVIDIA/Tegra/DeviceTree/BootOrderUfs.dts
@@ -10,7 +10,7 @@
 /plugin/;
 
 / {
-	overlay-name = "UEFI Boot order sata default";
+	overlay-name = "UEFI Boot order ufs default";
 
 	fragment@0 {
 		target-path = "/";
@@ -24,7 +24,7 @@
 					variables {
 						gNVIDIATokenSpaceGuid {
 							DefaultBootPriority {
-								data = "sata";
+								data = "ufs";
 								locked;
 							};
 						};

--- a/Silicon/NVIDIA/Tegra/DeviceTree/BootOrderUsb.dts
+++ b/Silicon/NVIDIA/Tegra/DeviceTree/BootOrderUsb.dts
@@ -10,7 +10,7 @@
 /plugin/;
 
 / {
-	overlay-name = "UEFI Boot order sata default";
+	overlay-name = "UEFI Boot order usb default";
 
 	fragment@0 {
 		target-path = "/";
@@ -24,7 +24,7 @@
 					variables {
 						gNVIDIATokenSpaceGuid {
 							DefaultBootPriority {
-								data = "sata";
+								data = "usb";
 								locked;
 							};
 						};

--- a/Silicon/NVIDIA/Tegra/DeviceTree/DeviceTree.inf
+++ b/Silicon/NVIDIA/Tegra/DeviceTree/DeviceTree.inf
@@ -17,6 +17,9 @@
 
 [Sources]
   AcpiBoot.dts
+  BootOrderNvme.dts
+  BootOrderPxe.dts
+  BootOrderSata.dts
   L4TConfiguration.dts
   L4TRootfsInfo.dts
   L4TRootfsABInfo.dts

--- a/Silicon/NVIDIA/Tegra/DeviceTree/DeviceTree.inf
+++ b/Silicon/NVIDIA/Tegra/DeviceTree/DeviceTree.inf
@@ -20,6 +20,8 @@
   BootOrderNvme.dts
   BootOrderPxe.dts
   BootOrderSata.dts
+  BootOrderUfs.dts
+  BootOrderUsb.dts
   L4TConfiguration.dts
   L4TRootfsInfo.dts
   L4TRootfsABInfo.dts


### PR DESCRIPTION
Add support for setting default boot order via a variable.
Currently supports class type options.
Future enhancement will add support for specifing the instance
of a device.

Variable that controls this is DefaultBootPriority and contains
a comma seperated string with the following values.

  "scsi"     - SCSI devices
  "usb"      - USB devices
  "sata"     - SATA devices
  "pxev4"    - IPv4 PXE boot
  "httpv4"   - IPv4 HTTP boot
  "pxev6"    - IPv6 PXE boot
  "httpv6"   - IPv6 HTTP boot
  "nvme"     - Nvme devices
  "ufs"      - UFS devices
  "sd"       - SD devices
  "emmc"     - eMMC devices
  "cdrom"    - CD/DVD drives
  "boot.img" - Android style boot.img partition

Any entries that are not in the list will be left at the end of the
boot order.

If the variable is not found "boot.img,usb,sd,emmc,ufs" is used
