### PR TITLE
feat(t194): Add DP support via multi-head & win

### DIFF
--- a/Silicon/NVIDIA/Tegra/T194/Drivers/T194GraphicsOutputDxe/T194GraphicsOutputDxe.h
+++ b/Silicon/NVIDIA/Tegra/T194/Drivers/T194GraphicsOutputDxe/T194GraphicsOutputDxe.h
@@ -16,22 +16,39 @@
 #include <Library/PcdLib.h>
 #include <Library/UefiLib.h>
 
-#define WINBUF_START_ADDR_LO_OFFSET              0x2000
-#define WINBUF_START_ADDR_HI_OFFSET              0x2034
-#define CORE_HEAD_SET_CONTROL_OUTPUT_LUT_OFFSET  0x10c4
 #define CORE_HEAD_SET_CONTROL_OUTPUT_LUT_SIZE(x)  BitFieldRead32 ((x), 1, 2)
-#define CORE_HEAD_SET_CONTROL_OUTPUT_LUT_SIZE_257   0x0
-#define CORE_HEAD_SET_CONTROL_OUTPUT_LUT_SIZE_1025  0x2
-#define COREPVT_HEAD_SET_OUTPUT_LUT_BASE_LO_OFFSET  0x10c8
-#define COREPVT_HEAD_SET_OUTPUT_LUT_BASE_HI_OFFSET  0x10cc
-#define DC_DISP_DISP_ACTIVE_OFFSET                  0x1024
-#define DC_DISP_DISP_ACTIVE_RESET_VAL               0x00040008
-#define DC_HEAD_OFFSET                              0x00010000
-#define WIN_COLOR_DEPTH_OFFSET                      0x2e0c
-#define WIN_COLOR_DEPTH_B8G8R8A8                    0xc
-#define WIN_COLOR_DEPTH_R8G8B8A8                    0xd
-#define PCALC_WINDOW_SET_CROPPED_SIZE_IN_OFFSET     0x2e18
-#define DC_A_WIN_AD_WIN_OPTIONS_OFFSET              0x2e00
+#define CORE_HEAD_SET_CONTROL_OUTPUT_LUT_SIZE_257       0x0
+#define CORE_HEAD_SET_CONTROL_OUTPUT_LUT_SIZE_1025      0x2
+#define CORE_HEAD_SET_CONTROL_OUTPUT_LUT_OFFSET         0x10c4
+#define COREPVT_HEAD_SET_OUTPUT_LUT_BASE_LO_OFFSET      0x10c8
+#define COREPVT_HEAD_SET_OUTPUT_LUT_BASE_HI_OFFSET      0x10cc
+#define DC_DISP_DISP_ACTIVE_OFFSET                      0x1024
+#define DC_DISP_DISP_ACTIVE_RESET_VAL                   0x00040008
+#define DC_PER_HEAD_OFFSET                              0x00010000
+#define DC_HEAD_0_BASE_ADDR                             0x15200000
+#define DC_HEAD_1_BASE_ADDR                             0x15210000
+#define DC_HEAD_2_BASE_ADDR                             0x15220000
+#define WIN_COLOR_DEPTH_OFFSET                          0x2e0c
+#define WIN_COLOR_DEPTH_B8G8R8A8                        0xc
+#define WIN_COLOR_DEPTH_R8G8B8A8                        0xd
+#define DC_WIN_A_PCALC_WINDOW_SET_CROPPED_SIZE_IN_0     0x1c18
+#define DC_A_WIN_AD_PCALC_WINDOW_SET_CROPPED_SIZE_IN_0  0x2e18
+#define DC_A_WIN_AD_WIN_OPTIONS_OFFSET                  0x2e00
+#define DC_A_WIN_AD_WIN_OPTIONS_AD_WIN_ENABLE_ENABLE    BIT30
+#define DC_A_WINBUF_AD_START_ADDR_OFFSET                0x2f00
+#define DC_A_WINBUF_AD_START_ADDR_HI_OFFSET             0x2f34
+
+#define DC_PER_WINDOW_OFFSET  0xc00
+#define WINDOW_INDEX_A        0x0
+#define WINDOW_INDEX_B        0x1
+#define WINDOW_INDEX_C        0x2
+#define WINDOW_INDEX_D        0x3
+#define WINDOW_INDEX_E        0x4
+#define WINDOW_INDEX_F        0x5
+#define WINDOW_INDEX_MAX      0x5
+
+#define WIN_CROPPED_SIZE_IN_MIN_HEIGHT  600
+#define WIN_CROPPED_SIZE_IN_MIN_WIDTH   800
 
 typedef struct {
   UINT32                                  Signature;


### PR DESCRIPTION
Add support for multi-head and multi-window enumeration.

This additional flexibility is needed to support the T194 Xavier NX Display Port configuration, as the T194 Jakku product's Device Tree specifies this disp config:

fb0: Head0->SOR1->HDMI Window A,B,C (window index 0,1,2)
fb1: Head1->SOR0->DP   Window D,E,F (window index 3,4,5)

Before this change, only Head0->WindowA was supported, which would only be HDMI on both Galen and Xavier NX.

Note_1: T194 GOP DP support is dependent on recently added CBoot-based nvdisp-init support.

Note_2: T194 GOP still only supports a single window on a single head, as before.

Note_3: The window dimensions must be at least 800x600, which is a requirement of the font/glyph handling code in EDK2, which fails at 640x480 and 720x480.

Signed-off-by: Aron Wong <awong@nvidia.com>
Reviewed-by: Tom Warren <twarren@nvidia.com>
Reviewed-by: Ashish Singhal <ashishsingha@nvidia.com>
Tested-by: Ashish Singhal <ashishsingha@nvidia.com>