### PR TITLE
fix(build): Fix stuart to version 0.17.1

### DIFF
--- a/Silicon/NVIDIA/scripts/prepare_stuart.sh
+++ b/Silicon/NVIDIA/scripts/prepare_stuart.sh
@@ -29,8 +29,8 @@ if [ ! -e venv/bin/activate ]; then
   . venv/bin/activate
   _msg "Installing required Python packages..."
   pip install --upgrade -r edk2/pip-requirements.txt
-  # Require at least stuart 0.17.1, which fixes a PackagePath reordering issue.
-  pip install --upgrade "edk2-pytool-extensions>=0.17.1"
+  # Require stuart 0.17.1, which fixes a PackagePath reordering issue.
+  pip install --upgrade "edk2-pytool-extensions==0.17.1"
 else
   _msg "Activating Python virtual environment."
   . venv/bin/activate


### PR DESCRIPTION
Make sure we use a known-good version of edk2-pytool-extensions, which is currently 0.17.1, instead of allowing pip to upgrade to the latest.

The 0.20.0 version of edk2-pytool-extensions pulls in the 0.12.x of edk2-pytool-library, which has code that requires Python 3.9 (although the dependency is not identified in the package metadata).  We want to maintain compatibility with older versions of Ubuntu which will have older versions of Python3.

Signed-off-by: Jake Garver <jake@nvidia.com>