### PR TITLE
Platform/NVIDIA: Use Metronome from MdeModulePkg instead of EmbeddedPkg

### DIFF
--- a/Platform/NVIDIA/NVIDIA.common.dsc.inc
+++ b/Platform/NVIDIA/NVIDIA.common.dsc.inc
@@ -572,11 +572,6 @@
   #
   gArmTokenSpaceGuid.PcdVFPEnabled|1
 
-  #
-  # Pltaform's Tick Period in 100 nS units
-  #
-  gEmbeddedTokenSpaceGuid.PcdMetronomeTickPeriod|1000
-
   # Use Segment numbers as PCI UID
   gEdkiiDynamicTablesPkgTokenSpaceGuid.PcdPciUseSegmentAsUid|TRUE
 
@@ -687,10 +682,10 @@
        NULL|SecurityPkg/Library/DxeImageVerificationLib/DxeImageVerificationLib.inf
   }
   MdeModulePkg/Universal/CapsuleRuntimeDxe/CapsuleRuntimeDxe.inf
+  MdeModulePkg/Universal/Metronome/Metronome.inf
   MdeModulePkg/Universal/MonotonicCounterRuntimeDxe/MonotonicCounterRuntimeDxe.inf
   MdeModulePkg/Universal/ResetSystemRuntimeDxe/ResetSystemRuntimeDxe.inf
   EmbeddedPkg/RealTimeClockRuntimeDxe/RealTimeClockRuntimeDxe.inf
-  EmbeddedPkg/MetronomeDxe/MetronomeDxe.inf
   MdeModulePkg/Universal/TimestampDxe/TimestampDxe.inf
   MdeModulePkg/Universal/StatusCodeHandler/RuntimeDxe/StatusCodeHandlerRuntimeDxe.inf
 

--- a/Platform/NVIDIA/NVIDIA.fvmain.fdf.inc
+++ b/Platform/NVIDIA/NVIDIA.fvmain.fdf.inc
@@ -21,10 +21,10 @@
   INF MdeModulePkg/Universal/SecurityStubDxe/SecurityStubDxe.inf
   INF MdeModulePkg/Universal/CapsuleRuntimeDxe/CapsuleRuntimeDxe.inf
   INF MdeModulePkg/Application/CapsuleApp/CapsuleApp.inf
+  INF MdeModulePkg/Universal/Metronome/Metronome.inf
   INF MdeModulePkg/Universal/MonotonicCounterRuntimeDxe/MonotonicCounterRuntimeDxe.inf
   INF MdeModulePkg/Universal/ResetSystemRuntimeDxe/ResetSystemRuntimeDxe.inf
   INF EmbeddedPkg/RealTimeClockRuntimeDxe/RealTimeClockRuntimeDxe.inf
-  INF EmbeddedPkg/MetronomeDxe/MetronomeDxe.inf
   INF Silicon/NVIDIA/Drivers/DefaultVariableDxe/DefaultVariableDxe.inf
   INF MdeModulePkg/Universal/Variable/RuntimeDxe/VariableRuntimeDxe.inf
   INF MdeModulePkg/Universal/Variable/RuntimeDxe/VariableSmmRuntimeDxe.inf


### PR DESCRIPTION
The EmbeddedPkg/MetronomeDxe should only be used on 32-bit platforms. Switch to MdeModulePkg/Universal/Metronome and remove the PcdMetronomeTickPeriod PCD.

Signed-off-by: Rebecca Cran <rebecca@bsdio.com>