### PR TITLE
fix(t234): thermal floorsweeping support

### DIFF
--- a/Silicon/NVIDIA/Library/FloorSweepingLib/FloorSweepingLib.inf
+++ b/Silicon/NVIDIA/Library/FloorSweepingLib/FloorSweepingLib.inf
@@ -1,6 +1,6 @@
 /** @file
 *
-*  Copyright (c) 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+*  Copyright (c) 2020-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 *
 *  SPDX-License-Identifier: BSD-2-Clause-Patent
 *
@@ -29,6 +29,7 @@
   DebugLib
   HobLib
   MceAriLib
+  MemoryAllocationLib
   NvgLib
   TegraPlatformInfoLib
   FloorSweepingInternalLib


### PR DESCRIPTION
Update thermal mappings to delete cooling device entries with deleted phandles, e.g. floorswept CPUs.

Signed-off-by: Bob Morgan <bobm@nvidia.com>
Tested-by: Ashish Singhal <ashishsingha@nvidia.com>
Reviewed-by: Ashish Singhal <ashishsingha@nvidia.com>