### PR TITLE
fix: Allow secure boot enablement on AGX Xavier platform

### DIFF
--- a/Silicon/NVIDIA/Drivers/DefaultVariableDxe/DefaultVariableDxe.inf
+++ b/Silicon/NVIDIA/Drivers/DefaultVariableDxe/DefaultVariableDxe.inf
@@ -1,7 +1,7 @@
 ## @file
 #  Provides support for default variable creation.
 #
-#  Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#  Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
@@ -29,6 +29,7 @@
   MdeModulePkg/MdeModulePkg.dec
   MdePkg/MdePkg.dec
   Silicon/NVIDIA/NVIDIA.dec
+  SecurityPkg/SecurityPkg.dec
 
 [LibraryClasses]
   UefiBootServicesTableLib
@@ -42,9 +43,13 @@
   FileHandleLib
   DevicePathLib
   PcdLib
+  SecureBootVariableLib
+  TegraPlatformInfoLib
+  DeviceTreeHelperLib
 
 [Pcd]
   gEfiMdeModulePkgTokenSpaceGuid.PcdMaxVariableSize                  ## CONSUMES
+  gEfiSecurityPkgTokenSpaceGuid.PcdUserPhysicalPresence
 
 [Guids]
   gNVIDIAPublicVariableGuid

--- a/Silicon/NVIDIA/Drivers/TegraPlatformInit/TegraPlatformInitDxe.inf
+++ b/Silicon/NVIDIA/Drivers/TegraPlatformInit/TegraPlatformInitDxe.inf
@@ -2,7 +2,7 @@
 #
 #  Tegra Platform Specific Configuration
 #
-#  Copyright (c) 2019-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#  Copyright (c) 2019-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
@@ -27,6 +27,7 @@
   ArmPlatformPkg/ArmPlatformPkg.dec
   Silicon/NVIDIA/NVIDIA.dec
   EmbeddedPkg/EmbeddedPkg.dec
+  SecurityPkg/SecurityPkg.dec
 
 [LibraryClasses]
   BaseLib
@@ -43,6 +44,7 @@
   DtPlatformDtbLoaderLib
   FloorSweepingLib
   FdtLib
+  SecureBootVariableLib
 
 [Guids]
   gEdkiiNvVarStoreFormattedGuid
@@ -64,6 +66,7 @@
   gNVIDIATokenSpaceGuid.PcdGpuToOwnCpuDistance
   gNVIDIATokenSpaceGuid.PcdGpuToOtherCpuDistance
   gNVIDIATokenSpaceGuid.PcdTegraStmmEnabled
+  gEfiSecurityPkgTokenSpaceGuid.PcdUserPhysicalPresence
 
 [Depex]
   TRUE


### PR DESCRIPTION
Currently the PcdUserPhysicalPresence PCD is set to FALSE to prevent users from being able to modify secure-boot related settings via the UEFI Menu.
This works well on most platforms/SOCs where StandaloneMm image is present to manage the variables.
On AGX Xavier, which doesn't have StandaloneMm to manage variables setting this PCD to FALSE prevents enrolling default keys and enabling secure-boot via the Key Enrollment App.
To workaround this issue set the PhysicalPresence Pcd to TRUE for AGX Xavier Devices to allow the default keys to be enrolled, and when the next reboot is done.

Signed-off-by: Girish Mahadevan <gmahadevan@nvidia.com>
Tested-by: Ashish Singhal <ashishsingha@nvidia.com>
Reviewed-by: Ashish Singhal <ashishsingha@nvidia.com>