### PR TITLE
fix: change use of deprecated EFI_D_* to DEBUG_*

### DIFF
--- a/Silicon/NVIDIA/Application/ClockUtil/ClockUtil.c
+++ b/Silicon/NVIDIA/Application/ClockUtil/ClockUtil.c
@@ -109,7 +109,7 @@ DisplayClockInfo (
   Status = mClockProtocol->GetClockAttributes (mClockProtocol, ClockId, &Enabled, ClockName);
   if (EFI_ERROR (Status)) {
     if (Status != EFI_NOT_FOUND) {
-      DEBUG ((EFI_D_ERROR, "Failed to get clock attributes - %d: %r\r\n", ClockId, Status));
+      DEBUG ((DEBUG_ERROR, "Failed to get clock attributes - %d: %r\r\n", ClockId, Status));
     }
 
     return;
@@ -117,7 +117,7 @@ DisplayClockInfo (
 
   Status = mClockParents->GetParent (mClockParents, ClockId, &ParentId);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "Failed to get parent for clock %d\r\n", ClockId));
+    DEBUG ((DEBUG_ERROR, "Failed to get parent for clock %d\r\n", ClockId));
     ParentId = MAX_UINT32;
   }
 

--- a/Silicon/NVIDIA/Application/FalconUtil/FalconUtil.c
+++ b/Silicon/NVIDIA/Application/FalconUtil/FalconUtil.c
@@ -165,7 +165,7 @@ InitializeFalconUtil (
                   );
   if (EFI_ERROR (Status) || (mXhciControllerProtocol == NULL)) {
     DEBUG ((
-      EFI_D_ERROR,
+      DEBUG_ERROR,
       "%a: Can't get XhciController Protocol Handle:%r\n",
       __FUNCTION__,
       Status
@@ -176,7 +176,7 @@ InitializeFalconUtil (
   /* Get the XHCI Config Registers Base Address */
   mXhciControllerProtocol->GetCfgAddr (mXhciControllerProtocol, &CfgAddress);
   if (CfgAddress == 0) {
-    DEBUG ((EFI_D_ERROR, "%a: Invalid Xhci Config Address Received\n"));
+    DEBUG ((DEBUG_ERROR, "%a: Invalid Xhci Config Address Received\n"));
     goto Done;
   }
 
@@ -276,7 +276,7 @@ InitializeFalconUtil (
     /* data */
     ValueStr = ShellCommandLineGetRawValue (ParamPackage, 1);
     if (ValueStr == NULL) {
-      DEBUG ((EFI_D_ERROR, "\nwrite value not provided\n\n", Value));
+      DEBUG ((DEBUG_ERROR, "\nwrite value not provided\n\n", Value));
       goto Done;
     }
 
@@ -301,7 +301,7 @@ InitializeFalconUtil (
     Value = ShellStrToUintn (ValueStr);
     if (Value >= DDIRECT_OFFSET) {
       DEBUG ((
-        EFI_D_ERROR,
+        DEBUG_ERROR,
         "\nDMEM Offset should be less than DMEM Size(0x2000)\n\n"
         ));
       goto Done;
@@ -313,7 +313,7 @@ InitializeFalconUtil (
     ValueStr = ShellCommandLineGetRawValue (ParamPackage, 1);
     if (ValueStr == NULL) {
       DEBUG ((
-        EFI_D_ERROR,
+        DEBUG_ERROR,
         "\nProvide number of DWORDS to read from DMEM\n\n"
         ));
       goto Done;
@@ -364,7 +364,7 @@ InitializeFalconUtil (
     Value = ShellStrToUintn (ValueStr);
     if (Value < DDIRECT_OFFSET) {
       DEBUG ((
-        EFI_D_ERROR,
+        DEBUG_ERROR,
         "\nAddress should be more than DDIRECT Start Address(0x2000)\n\n"
         ));
       goto Done;
@@ -376,7 +376,7 @@ InitializeFalconUtil (
     ValueStr = ShellCommandLineGetRawValue (ParamPackage, 1);
     if (ValueStr == NULL) {
       DEBUG ((
-        EFI_D_ERROR,
+        DEBUG_ERROR,
         "\nProvide number of DWORDS to Read from DDIRECT\n\n"
         ));
       goto Done;

--- a/Silicon/NVIDIA/Drivers/BpmpI2c/BpmpI2cDxe.c
+++ b/Silicon/NVIDIA/Drivers/BpmpI2c/BpmpI2cDxe.c
@@ -91,7 +91,7 @@ BpmpIpcProcess (
     Private->TransferInProgress = FALSE;
     if (NULL != Token) {
       if (EFI_ERROR (Token->TransactionStatus)) {
-        DEBUG ((EFI_D_ERROR, "%a: I2C transfer failed async: %r, %08x\r\n", __FUNCTION__, Token->TransactionStatus, Private->MessageError));
+        DEBUG ((DEBUG_ERROR, "%a: I2C transfer failed async: %r, %08x\r\n", __FUNCTION__, Token->TransactionStatus, Private->MessageError));
         *Private->TransactionStatus = EFI_DEVICE_ERROR;
         Private->RequestPacket      = NULL;
         if (Private->TransactionEvent != NULL) {
@@ -182,7 +182,7 @@ BpmpIpcProcess (
                                &Private->MessageError
                                );
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "%a: I2C transfer failed sync: %r, %08x\r\n", __FUNCTION__, Status, Private->MessageError));
+    DEBUG ((DEBUG_ERROR, "%a: I2C transfer failed sync: %r, %08x\r\n", __FUNCTION__, Status, Private->MessageError));
     *Private->TransactionStatus = EFI_DEVICE_ERROR;
     Private->RequestPacket      = NULL;
     if (Private->TransactionEvent != NULL) {
@@ -690,7 +690,7 @@ BuildI2cDevices (
     Private->I2cDevices[Index].I2cBusConfiguration = 0;
     RegEntry                                       = (CONST UINT32 *)fdt_getprop (Private->DeviceTreeBase, Node, "reg", &RegLength);
     if ((RegEntry == NULL) || (RegLength != sizeof (UINT32))) {
-      DEBUG ((EFI_D_ERROR, "%a: Failed to locate reg property\r\n", __FUNCTION__));
+      DEBUG ((DEBUG_ERROR, "%a: Failed to locate reg property\r\n", __FUNCTION__));
       Private->I2cDevices[Index].SlaveAddressCount = 0;
       Private->I2cDevices[Index].SlaveAddressArray = NULL;
       break;
@@ -765,7 +765,7 @@ BpmpI2cStart (
                   EFI_OPEN_PROTOCOL_GET_PROTOCOL
                   );
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "%a: Failed to get BpmpIpc protocol %r\r\n", __FUNCTION__, Status));
+    DEBUG ((DEBUG_ERROR, "%a: Failed to get BpmpIpc protocol %r\r\n", __FUNCTION__, Status));
     goto ErrorExit;
   }
 
@@ -781,7 +781,7 @@ BpmpI2cStart (
                   EFI_OPEN_PROTOCOL_GET_PROTOCOL
                   );
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "%a: Failed to get device path protocol %r\r\n", __FUNCTION__, Status));
+    DEBUG ((DEBUG_ERROR, "%a: Failed to get device path protocol %r\r\n", __FUNCTION__, Status));
     goto ErrorExit;
   }
 
@@ -797,20 +797,20 @@ BpmpI2cStart (
                   EFI_OPEN_PROTOCOL_GET_PROTOCOL
                   );
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "%a: Failed to get device tree node protocol %r\r\n", __FUNCTION__, Status));
+    DEBUG ((DEBUG_ERROR, "%a: Failed to get device tree node protocol %r\r\n", __FUNCTION__, Status));
     goto ErrorExit;
   }
 
   Private = (NVIDIA_BPMP_I2C_PRIVATE_DATA *)AllocateZeroPool (sizeof (NVIDIA_BPMP_I2C_PRIVATE_DATA));
   if (NULL == Private) {
-    DEBUG ((EFI_D_ERROR, "%a: Failed to allocate private data\r\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Failed to allocate private data\r\n", __FUNCTION__));
     Status = EFI_OUT_OF_RESOURCES;
     goto ErrorExit;
   }
 
   Private->ChildDevicePath = AppendDevicePathNode (ParentDevicePath, (EFI_DEVICE_PATH_PROTOCOL *)&mDevicePathNode);
   if (NULL == Private->ChildDevicePath) {
-    DEBUG ((EFI_D_ERROR, "%a: Failed to allocate device path\r\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Failed to allocate device path\r\n", __FUNCTION__));
     Status = EFI_OUT_OF_RESOURCES;
     goto ErrorExit;
   }
@@ -839,7 +839,7 @@ BpmpI2cStart (
                                                               "nvidia,tegra186-bpmp-i2c"
                                                               );
   if (0 == Private->DeviceTreeNodeOffset) {
-    DEBUG ((EFI_D_ERROR, "%a: Failed to locate bpmp-i2c device tree node\r\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Failed to locate bpmp-i2c device tree node\r\n", __FUNCTION__));
     Status = EFI_NOT_FOUND;
     goto ErrorExit;
   }
@@ -848,7 +848,7 @@ BpmpI2cStart (
   if ((Adapter == NULL) || (AdapterLength != sizeof (UINT32))) {
     Adapter = (CONST UINT32 *)fdt_getprop (Private->DeviceTreeBase, Private->DeviceTreeNodeOffset, "adapter", &AdapterLength);
     if ((Adapter == NULL) || (AdapterLength != sizeof (UINT32))) {
-      DEBUG ((EFI_D_ERROR, "%a: Failed to locate adapter property\r\n", __FUNCTION__));
+      DEBUG ((DEBUG_ERROR, "%a: Failed to locate adapter property\r\n", __FUNCTION__));
       Status = EFI_NOT_FOUND;
       goto ErrorExit;
     }
@@ -858,7 +858,7 @@ BpmpI2cStart (
 
   Status = BuildI2cDevices (Private);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "%a: Failed to enumerate i2c devices: %r\r\n", __FUNCTION__, Status));
+    DEBUG ((DEBUG_ERROR, "%a: Failed to enumerate i2c devices: %r\r\n", __FUNCTION__, Status));
     goto ErrorExit;
   }
 
@@ -875,7 +875,7 @@ BpmpI2cStart (
                   &Private->BpmpIpcToken.Event
                   );
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "%a: Failed to create BpmpIpcEvent: %R\r\n", __FUNCTION__, Status));
+    DEBUG ((DEBUG_ERROR, "%a: Failed to create BpmpIpcEvent: %R\r\n", __FUNCTION__, Status));
     goto ErrorExit;
   }
 
@@ -894,7 +894,7 @@ BpmpI2cStart (
                   NULL
                   );
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "%a: Failed to install i2c protocols:%r\r\n", __FUNCTION__, Status));
+    DEBUG ((DEBUG_ERROR, "%a: Failed to install i2c protocols:%r\r\n", __FUNCTION__, Status));
     goto ErrorExit;
   }
 
@@ -907,7 +907,7 @@ BpmpI2cStart (
                   NULL
                   );
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "%a: Failed to install callerid protocol:%r\r\n", __FUNCTION__, Status));
+    DEBUG ((DEBUG_ERROR, "%a: Failed to install callerid protocol:%r\r\n", __FUNCTION__, Status));
     goto ErrorExit;
   }
 
@@ -923,7 +923,7 @@ BpmpI2cStart (
                   EFI_OPEN_PROTOCOL_BY_CHILD_CONTROLLER
                   );
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "%a: Failed open by child %r\r\n", __FUNCTION__, Status));
+    DEBUG ((DEBUG_ERROR, "%a: Failed open by child %r\r\n", __FUNCTION__, Status));
     goto ErrorExit;
   }
 
@@ -1104,7 +1104,7 @@ BpmpI2cInitialize (
              );
 
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "%a: Failed to install driver binding protocol: %r\r\n", __FUNCTION__, Status));
+    DEBUG ((DEBUG_ERROR, "%a: Failed to install driver binding protocol: %r\r\n", __FUNCTION__, Status));
     return Status;
   }
 

--- a/Silicon/NVIDIA/Drivers/BpmpIpc/BpmpIpc.c
+++ b/Silicon/NVIDIA/Drivers/BpmpIpc/BpmpIpc.c
@@ -162,7 +162,7 @@ ProcessTransaction (
 
   // Validate channels are empty
   if (!ChannelFree (PrivateData->RxChannel) || !ChannelFree (PrivateData->TxChannel)) {
-    DEBUG ((EFI_D_ERROR, "%a: Channel not idle\r\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Channel not idle\r\n", __FUNCTION__));
     ASSERT (FALSE);
 
     OldTpl = gBS->RaiseTPL (TPL_NOTIFY);
@@ -202,7 +202,7 @@ ProcessTransaction (
                        TimerTick
                        );
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "%a: Failed to set timer:%r\r\n", __FUNCTION__, Status));
+      DEBUG ((DEBUG_ERROR, "%a: Failed to set timer:%r\r\n", __FUNCTION__, Status));
 
       OldTpl = gBS->RaiseTPL (TPL_NOTIFY);
       RemoveEntryList (List);
@@ -455,7 +455,7 @@ MoveTxChannelState (
                                                                    HspDoorbellBpmp
                                                                    );
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "%a: Failed to ring doorbell: %r\r\n", __FUNCTION__, Status));
+    DEBUG ((DEBUG_ERROR, "%a: Failed to ring doorbell: %r\r\n", __FUNCTION__, Status));
   }
 
   return Status;
@@ -559,7 +559,7 @@ HspProtocolNotify (
                   );
 
   if (EFI_ERROR (Status) || (NumberOfHandles == 0)) {
-    DEBUG ((EFI_D_ERROR, "%a: Locate Handle:%r\r\n", __FUNCTION__, Status));
+    DEBUG ((DEBUG_ERROR, "%a: Locate Handle:%r\r\n", __FUNCTION__, Status));
     return;
   }
 
@@ -572,7 +572,7 @@ HspProtocolNotify (
                   (VOID **)&PrivateData->DoorbellProtocol
                   );
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "%a: Handle Protocol %r\r\n", __FUNCTION__, Status));
+    DEBUG ((DEBUG_ERROR, "%a: Handle Protocol %r\r\n", __FUNCTION__, Status));
     PrivateData->DoorbellHandle = NULL;
     return;
   }
@@ -588,13 +588,13 @@ HspProtocolNotify (
                                             );
 
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "%a, Failed to enable doorbell channel: %r", __FUNCTION__, Status));
+    DEBUG ((DEBUG_ERROR, "%a, Failed to enable doorbell channel: %r", __FUNCTION__, Status));
     return;
   }
 
   Status = InitializeIvcChannel (PrivateData);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "%a, Failed to initialize channel: %r", __FUNCTION__, Status));
+    DEBUG ((DEBUG_ERROR, "%a, Failed to initialize channel: %r", __FUNCTION__, Status));
     return;
   }
 
@@ -605,7 +605,7 @@ HspProtocolNotify (
                   NULL
                   );
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "%a, Failed to install protocol: %r", __FUNCTION__, Status));
+    DEBUG ((DEBUG_ERROR, "%a, Failed to install protocol: %r", __FUNCTION__, Status));
     return;
   }
 
@@ -659,7 +659,7 @@ BpmpIpcProtocolInit (
                   &PrivateData->TimerEvent
                   );
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "%a: Failed to create timer event: %r\r\n", __FUNCTION__, Status));
+    DEBUG ((DEBUG_ERROR, "%a: Failed to create timer event: %r\r\n", __FUNCTION__, Status));
     goto ErrorExit;
   }
 
@@ -707,7 +707,7 @@ BpmpIpcProtocolInit (
                                        &PrivateData->ProtocolNotifyToken
                                        );
   if (NULL == PrivateData->RegisterNotifyEvent) {
-    DEBUG ((EFI_D_ERROR, "%a: Enable Channel\r\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Enable Channel\r\n", __FUNCTION__));
     Status = EFI_DEVICE_ERROR;
     goto ErrorExit;
   }

--- a/Silicon/NVIDIA/Drivers/BpmpIpc/BpmpIpcDxe.c
+++ b/Silicon/NVIDIA/Drivers/BpmpIpc/BpmpIpcDxe.c
@@ -179,7 +179,7 @@ BpmpIpcInitialize (
                     NULL
                     );
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "%a, Failed to install protocol: %r", __FUNCTION__, Status));
+      DEBUG ((DEBUG_ERROR, "%a, Failed to install protocol: %r", __FUNCTION__, Status));
     }
 
     return Status;
@@ -204,7 +204,7 @@ BpmpIpcInitialize (
     DeviceHandle = NULL;
     Device       = (NON_DISCOVERABLE_DEVICE *)AllocatePool (sizeof (NON_DISCOVERABLE_DEVICE));
     if (NULL == Device) {
-      DEBUG ((EFI_D_ERROR, "%a: Failed to allocate device protocol.\r\n", __FUNCTION__));
+      DEBUG ((DEBUG_ERROR, "%a: Failed to allocate device protocol.\r\n", __FUNCTION__));
       return EFI_DEVICE_ERROR;
     }
 

--- a/Silicon/NVIDIA/Drivers/BpmpIpc/HspDoorbell.c
+++ b/Silicon/NVIDIA/Drivers/BpmpIpc/HspDoorbell.c
@@ -97,7 +97,7 @@ HspDoorbellEnableChannel (
     1
     );
 
-  DEBUG ((EFI_D_ERROR, "%a: Waiting for HSP Doorbell Channel Enabled.\r\n", __FUNCTION__));
+  DEBUG ((DEBUG_ERROR, "%a: Waiting for HSP Doorbell Channel Enabled.\r\n", __FUNCTION__));
   while (0 == MmioBitFieldRead32 (
                 PrivateData->DoorbellLocation[Doorbell] + HSP_DB_REG_ENABLE,
                 HSP_MASTER_CCPLEX,
@@ -113,7 +113,7 @@ HspDoorbellEnableChannel (
     }
   }
 
-  DEBUG ((EFI_D_ERROR, "%a: HSP Doorbell Channel Enabled.\r\n", __FUNCTION__));
+  DEBUG ((DEBUG_ERROR, "%a: HSP Doorbell Channel Enabled.\r\n", __FUNCTION__));
 
   return EFI_SUCCESS;
 }
@@ -157,7 +157,7 @@ HspDoorbellProtocolInit (
       (NonDiscoverableProtocol->Resources->Desc != ACPI_ADDRESS_SPACE_DESCRIPTOR) ||
       (NonDiscoverableProtocol->Resources->ResType != ACPI_ADDRESS_SPACE_TYPE_MEM))
   {
-    DEBUG ((EFI_D_ERROR, "%a: Invalid node resources.\r\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Invalid node resources.\r\n", __FUNCTION__));
     Status = EFI_DEVICE_ERROR;
     goto ErrorExit;
   }

--- a/Silicon/NVIDIA/Drivers/BpmpScmi/ScmiClockProtocol.c
+++ b/Silicon/NVIDIA/Drivers/BpmpScmi/ScmiClockProtocol.c
@@ -191,7 +191,7 @@ ClockGetClockAttributes (
   ClockAsciiName[SCMI_MAX_STR_LEN - 1] = '\0';
 
   if (AsciiStrSize (Response.Name) > SCMI_MAX_STR_LEN) {
-    DEBUG ((EFI_D_VERBOSE, "String %a, too large truncated to %a\r\n", Response.Name, ClockAsciiName));
+    DEBUG ((DEBUG_VERBOSE, "String %a, too large truncated to %a\r\n", Response.Name, ClockAsciiName));
     Status = EFI_WARN_BUFFER_TOO_SMALL;
   }
 
@@ -314,7 +314,7 @@ ClockSetParentByDesiredRate (
 
   Status = mClockParentsProtocol.GetParents (&mClockParentsProtocol, ClockId, &NumberOfParents, &ParentIds);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_INFO, "%a Failed to get parent info for clock %d\r\n", __FUNCTION__, ClockId));
+    DEBUG ((DEBUG_INFO, "%a Failed to get parent info for clock %d\r\n", __FUNCTION__, ClockId));
     return EFI_SUCCESS;
   }
 
@@ -325,7 +325,7 @@ ClockSetParentByDesiredRate (
     UINT64  Divider;
     Status = This->RateGet (This, ParentIds[ParentIndex], &ParentRate);
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "%a: Failed to get parent rate for parent %d\r\n", __FUNCTION__, ParentIds[ParentIndex]));
+      DEBUG ((DEBUG_ERROR, "%a: Failed to get parent rate for parent %d\r\n", __FUNCTION__, ParentIds[ParentIndex]));
       return Status;
     }
 
@@ -339,20 +339,20 @@ ClockSetParentByDesiredRate (
   }
 
   if (ClosestParent == MAX_UINT32) {
-    DEBUG ((EFI_D_VERBOSE, "%a: No available parent\r\n", __FUNCTION__));
+    DEBUG ((DEBUG_VERBOSE, "%a: No available parent\r\n", __FUNCTION__));
     return EFI_SUCCESS;
   }
 
   // Enable and set the parent
   Status = ScmiClock2Protocol.Enable (&ScmiClock2Protocol, ClosestParent, TRUE);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "%a: Failed to enable parent %d\r\n", __FUNCTION__, ClosestParent));
+    DEBUG ((DEBUG_ERROR, "%a: Failed to enable parent %d\r\n", __FUNCTION__, ClosestParent));
     return Status;
   }
 
   Status = mClockParentsProtocol.SetParent (&mClockParentsProtocol, ClockId, ClosestParent);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "%a: Failed to set parent %d for clock %d\r\n", __FUNCTION__, ClosestParent, ClockId));
+    DEBUG ((DEBUG_ERROR, "%a: Failed to set parent %d for clock %d\r\n", __FUNCTION__, ClosestParent, ClockId));
     return Status;
   }
 
@@ -392,7 +392,7 @@ ClockRateSet (
 
   Status = ClockSetParentByDesiredRate (This, ClockId, Rate);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "%a: Failed to set parent for clock %d, rate %d\r\n", __FUNCTION__, ClockId, Rate));
+    DEBUG ((DEBUG_ERROR, "%a: Failed to set parent for clock %d, rate %d\r\n", __FUNCTION__, ClockId, Rate));
     return Status;
   }
 
@@ -418,7 +418,7 @@ ClockRateSet (
     Status = EFI_SUCCESS;
   } else if (Rate != NewRate) {
     DEBUG ((
-      EFI_D_INFO,
+      DEBUG_INFO,
       "%a: Clock %d, attempt set to %16ld, was set to %16ld\r\n",
       __FUNCTION__,
       ClockId,
@@ -466,7 +466,7 @@ ClockEnable (
     if (!EFI_ERROR (Status)) {
       Status = ScmiClock2Protocol.Enable (&ScmiClock2Protocol, ParentId, TRUE);
       if (EFI_ERROR (Status)) {
-        DEBUG ((EFI_D_ERROR, "%a: Failed to enable parent clock %d for %d: %r\r\n", __FUNCTION__, ParentId, ClockId, Status));
+        DEBUG ((DEBUG_ERROR, "%a: Failed to enable parent clock %d for %d: %r\r\n", __FUNCTION__, ParentId, ClockId, Status));
       }
     }
   }

--- a/Silicon/NVIDIA/Drivers/DeviceDiscovery/DeviceDiscoveryDxe.c
+++ b/Silicon/NVIDIA/Drivers/DeviceDiscovery/DeviceDiscoveryDxe.c
@@ -64,7 +64,7 @@ AddMemoryRegion (
 
     Status = gDS->GetMemorySpaceDescriptor (ScanLocation, &MemorySpace);
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "%a: Failed to GetMemorySpaceDescriptor (0x%llx): %r.\r\n", __FUNCTION__, ScanLocation, Status));
+      DEBUG ((DEBUG_ERROR, "%a: Failed to GetMemorySpaceDescriptor (0x%llx): %r.\r\n", __FUNCTION__, ScanLocation, Status));
       return Status;
     }
 
@@ -77,7 +77,7 @@ AddMemoryRegion (
                       EFI_MEMORY_UC | EFI_MEMORY_RUNTIME
                       );
       if (EFI_ERROR (Status)) {
-        DEBUG ((EFI_D_ERROR, "%a: Failed to AddMemorySpace: (0x%llx, 0x%llx) %r.\r\n", __FUNCTION__, ScanLocation, OverlapSize, Status));
+        DEBUG ((DEBUG_ERROR, "%a: Failed to AddMemorySpace: (0x%llx, 0x%llx) %r.\r\n", __FUNCTION__, ScanLocation, OverlapSize, Status));
         return Status;
       }
 
@@ -87,7 +87,7 @@ AddMemoryRegion (
                       EFI_MEMORY_UC
                       );
       if (EFI_ERROR (Status)) {
-        DEBUG ((EFI_D_ERROR, "%a: Failed to SetMemorySpaceAttributes: (0x%llx, 0x%llx) %r.\r\n", __FUNCTION__, ScanLocation, OverlapSize, Status));
+        DEBUG ((DEBUG_ERROR, "%a: Failed to SetMemorySpaceAttributes: (0x%llx, 0x%llx) %r.\r\n", __FUNCTION__, ScanLocation, OverlapSize, Status));
         return Status;
       }
     }
@@ -153,7 +153,7 @@ GetResources (
       (SizeCells > 2) ||
       (SizeCells == 0))
   {
-    DEBUG ((EFI_D_ERROR, "%a: Bad cell values, %d, %d\r\n", __FUNCTION__, AddressCells, SizeCells));
+    DEBUG ((DEBUG_ERROR, "%a: Bad cell values, %d, %d\r\n", __FUNCTION__, AddressCells, SizeCells));
     return EFI_UNSUPPORTED;
   }
 
@@ -187,7 +187,7 @@ GetResources (
 
     AllocResources = (EFI_ACPI_ADDRESS_SPACE_DESCRIPTOR *)AllocateZeroPool (AllocationSize);
     if (NULL == AllocResources) {
-      DEBUG ((EFI_D_ERROR, "%a: Failed to allocate ACPI resources.\r\n", __FUNCTION__));
+      DEBUG ((DEBUG_ERROR, "%a: Failed to allocate ACPI resources.\r\n", __FUNCTION__));
       return EFI_OUT_OF_RESOURCES;
     }
   } else {
@@ -228,7 +228,7 @@ GetResources (
     Status = AddMemoryRegion (Private, AddressBase, RegionSize);
     if (EFI_ERROR (Status)) {
       DEBUG ((
-        EFI_D_ERROR,
+        DEBUG_ERROR,
         "%a: Failed to add region 0x%016lx, 0x%016lx: %r.\r\n",
         __FUNCTION__,
         AddressBase,
@@ -252,7 +252,7 @@ GetResources (
 
     if (SharedMemOffset <= 0) {
       DEBUG ((
-        EFI_D_ERROR,
+        DEBUG_ERROR,
         "%a: Unable to locate shared memory handle %u\r\n",
         __FUNCTION__,
         Handle
@@ -265,7 +265,7 @@ GetResources (
     ParentOffset = fdt_parent_offset (Private->DeviceTreeBase, SharedMemOffset);
     if (ParentOffset < 0) {
       DEBUG ((
-        EFI_D_ERROR,
+        DEBUG_ERROR,
         "%a: Unable to locate shared memory handle's parent %u\r\n",
         __FUNCTION__,
         Handle
@@ -283,7 +283,7 @@ GetResources (
         (SizeCells > 2) ||
         (SizeCells == 0))
     {
-      DEBUG ((EFI_D_ERROR, "%a: Bad cell values, %d, %d\r\n", __FUNCTION__, AddressCells, SizeCells));
+      DEBUG ((DEBUG_ERROR, "%a: Bad cell values, %d, %d\r\n", __FUNCTION__, AddressCells, SizeCells));
       return EFI_UNSUPPORTED;
     }
 
@@ -295,7 +295,7 @@ GetResources (
                     );
     if ((RegProperty == NULL) || (PropertySize == 0)) {
       DEBUG ((
-        EFI_D_ERROR,
+        DEBUG_ERROR,
         "%a: Invalid reg entry %p, %u, for handle %u\r\n",
         __FUNCTION__,
         RegProperty,
@@ -306,7 +306,7 @@ GetResources (
       EntrySize = sizeof (UINT32) * (AddressCells + SizeCells);
       ASSERT ((PropertySize % EntrySize) == 0);
       if (PropertySize != EntrySize) {
-        DEBUG ((EFI_D_ERROR, "%a: Ignoring secondary parent regions\r\n", __FUNCTION__));
+        DEBUG ((DEBUG_ERROR, "%a: Ignoring secondary parent regions\r\n", __FUNCTION__));
       }
 
       CopyMem ((VOID *)&ParentAddressBase, RegProperty, AddressCells * sizeof (UINT32));
@@ -325,7 +325,7 @@ GetResources (
         (SizeCells > 2) ||
         (SizeCells == 0))
     {
-      DEBUG ((EFI_D_ERROR, "%a: Bad cell values, %d, %d\r\n", __FUNCTION__, AddressCells, SizeCells));
+      DEBUG ((DEBUG_ERROR, "%a: Bad cell values, %d, %d\r\n", __FUNCTION__, AddressCells, SizeCells));
       return EFI_UNSUPPORTED;
     }
 
@@ -337,7 +337,7 @@ GetResources (
                     );
     if ((RegProperty == NULL) || (PropertySize == 0)) {
       DEBUG ((
-        EFI_D_ERROR,
+        DEBUG_ERROR,
         "%a: Invalid reg entry %p, %u, for handle %u\r\n",
         __FUNCTION__,
         RegProperty,
@@ -352,7 +352,7 @@ GetResources (
     EntrySize = sizeof (UINT32) * (AddressCells + SizeCells);
     ASSERT ((PropertySize % EntrySize) == 0);
     if (PropertySize != EntrySize) {
-      DEBUG ((EFI_D_ERROR, "%a: Ignoring secondary smem regions\r\n", __FUNCTION__));
+      DEBUG ((DEBUG_ERROR, "%a: Ignoring secondary smem regions\r\n", __FUNCTION__));
     }
 
     CopyMem ((VOID *)&AddressBase, RegProperty, AddressCells * sizeof (UINT32));
@@ -385,7 +385,7 @@ GetResources (
     Status = AddMemoryRegion (Private, AddressBase, RegionSize);
     if (EFI_ERROR (Status)) {
       DEBUG ((
-        EFI_D_ERROR,
+        DEBUG_ERROR,
         "%a: Failed to add region 0x%016lx, 0x%016lx: %r.\r\n",
         __FUNCTION__,
         AddressBase,
@@ -759,7 +759,7 @@ GetResetNodeProtocol (
     NumberOfResets = 0;
   } else {
     if ((ResetsLength % (sizeof (UINT32) * 2)) != 0) {
-      DEBUG ((EFI_D_ERROR, "%a, Resets length unexpected %d\r\n", __FUNCTION__, ResetsLength));
+      DEBUG ((DEBUG_ERROR, "%a, Resets length unexpected %d\r\n", __FUNCTION__, ResetsLength));
       return;
     }
 
@@ -768,7 +768,7 @@ GetResetNodeProtocol (
 
   ResetNode = (NVIDIA_RESET_NODE_PROTOCOL *)AllocatePool (sizeof (NVIDIA_RESET_NODE_PROTOCOL) + (NumberOfResets * sizeof (NVIDIA_RESET_NODE_ENTRY)));
   if (NULL == ResetNode) {
-    DEBUG ((EFI_D_ERROR, "%a, Failed to allocate reset node\r\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a, Failed to allocate reset node\r\n", __FUNCTION__));
     return;
   }
 
@@ -957,7 +957,7 @@ GetClockNodeProtocol (
     NumberOfClocks = 0;
   } else {
     if ((ClocksLength % (sizeof (UINT32) * 2)) != 0) {
-      DEBUG ((EFI_D_ERROR, "%a, Clock length unexpected %d\r\n", __FUNCTION__, ClocksLength));
+      DEBUG ((DEBUG_ERROR, "%a, Clock length unexpected %d\r\n", __FUNCTION__, ClocksLength));
       return;
     }
 
@@ -966,7 +966,7 @@ GetClockNodeProtocol (
 
   ClockNode = (NVIDIA_CLOCK_NODE_PROTOCOL *)AllocatePool (sizeof (NVIDIA_CLOCK_NODE_PROTOCOL) + (NumberOfClocks * sizeof (NVIDIA_CLOCK_NODE_ENTRY)));
   if (NULL == ClockNode) {
-    DEBUG ((EFI_D_ERROR, "%a, Failed to allocate clock node\r\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a, Failed to allocate clock node\r\n", __FUNCTION__));
     return;
   }
 
@@ -1195,7 +1195,7 @@ GetPowerGateNodeProtocol (
   }
 
   if ((PgLength % (sizeof (UINT32) * 2)) != 0) {
-    DEBUG ((EFI_D_ERROR, "%a, Power Gate length unexpected %d\r\n", __FUNCTION__, PgLength));
+    DEBUG ((DEBUG_ERROR, "%a, Power Gate length unexpected %d\r\n", __FUNCTION__, PgLength));
     return;
   }
 
@@ -1203,7 +1203,7 @@ GetPowerGateNodeProtocol (
 
   PgNode = (NVIDIA_POWER_GATE_NODE_PROTOCOL *)AllocatePool (sizeof (NVIDIA_POWER_GATE_NODE_PROTOCOL) + (NumberOfPgs * sizeof (UINT32)));
   if (NULL == PgNode) {
-    DEBUG ((EFI_D_ERROR, "%a, Failed to allocate power gate node\r\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a, Failed to allocate power gate node\r\n", __FUNCTION__));
     return;
   }
 
@@ -1297,7 +1297,7 @@ ProcessDeviceTreeNodeWithHandle (
 
   Device = (NON_DISCOVERABLE_DEVICE *)AllocatePool (sizeof (NON_DISCOVERABLE_DEVICE));
   if (NULL == Device) {
-    DEBUG ((EFI_D_ERROR, "%a: Failed to allocate device protocol.\r\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Failed to allocate device protocol.\r\n", __FUNCTION__));
     goto ErrorExit;
   }
 
@@ -1314,7 +1314,7 @@ ProcessDeviceTreeNodeWithHandle (
 
   Status = GetResources (Private, NodeOffset, &Device->Resources);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "%a: Failed to get node resources: %r.\r\n", __FUNCTION__, Status));
+    DEBUG ((DEBUG_ERROR, "%a: Failed to get node resources: %r.\r\n", __FUNCTION__, Status));
     goto ErrorExit;
   }
 
@@ -1342,7 +1342,7 @@ ProcessDeviceTreeNodeWithHandle (
     if ((Device->Resources->Desc != ACPI_ADDRESS_SPACE_DESCRIPTOR) ||
         (Device->Resources->ResType != ACPI_ADDRESS_SPACE_TYPE_MEM))
     {
-      DEBUG ((EFI_D_ERROR, "%a: Invalid node resources.\r\n", __FUNCTION__));
+      DEBUG ((DEBUG_ERROR, "%a: Invalid node resources.\r\n", __FUNCTION__));
       goto ErrorExit;
     } else {
       DevicePath->MemMap.MemMap.Header.Type     = HARDWARE_DEVICE_PATH;
@@ -1362,7 +1362,7 @@ ProcessDeviceTreeNodeWithHandle (
 
   NodeProtocolCopy = AllocateCopyPool (sizeof (NodeProtocol), (VOID *)&NodeProtocol);
   if (NULL == NodeProtocolCopy) {
-    DEBUG ((EFI_D_ERROR, "%a: Failed to allocate node protocol.\r\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Failed to allocate node protocol.\r\n", __FUNCTION__));
     goto ErrorExit;
   }
 
@@ -1390,7 +1390,7 @@ ProcessDeviceTreeNodeWithHandle (
                   NULL
                   );
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "%a: Failed to get install protocols: %r.\r\n", __FUNCTION__, Status));
+    DEBUG ((DEBUG_ERROR, "%a: Failed to get install protocols: %r.\r\n", __FUNCTION__, Status));
     goto ErrorExit;
   }
 
@@ -1406,7 +1406,7 @@ ProcessDeviceTreeNodeWithHandle (
                     NULL
                     );
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "%a: Failed to get install optional protocols: %r.\r\n", __FUNCTION__, Status));
+      DEBUG ((DEBUG_ERROR, "%a: Failed to get install optional protocols: %r.\r\n", __FUNCTION__, Status));
       UINTN  ProtocolUninstallIndex = 0;
       for (ProtocolUninstallIndex = 0; ProtocolUninstallIndex < ProtocolIndex; ProtocolUninstallIndex++) {
         gBS->UninstallMultipleProtocolInterfaces (
@@ -1494,7 +1494,7 @@ CompatibilityProtocolNotification (
                   );
   if (EFI_ERROR (Status)) {
     if (Status != EFI_NOT_FOUND) {
-      DEBUG ((EFI_D_ERROR, "%a: LocateHandleBuffer returned %r.\r\n", __FUNCTION__, Status));
+      DEBUG ((DEBUG_ERROR, "%a: LocateHandleBuffer returned %r.\r\n", __FUNCTION__, Status));
     }
 
     return;
@@ -1553,7 +1553,7 @@ DeviceDiscoveryDxeEntryPoint (
 
   Status = DtPlatformLoadDtb (&Private->DeviceTreeBase, &Private->DeviceTreeSize);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "%a: Failed to get device tree: %r.\r\n", __FUNCTION__, Status));
+    DEBUG ((DEBUG_ERROR, "%a: Failed to get device tree: %r.\r\n", __FUNCTION__, Status));
     goto ErrorExit;
   }
 
@@ -1566,7 +1566,7 @@ DeviceDiscoveryDxeEntryPoint (
                                          );
   if (NULL == Private->ProtocolNotificationEvent) {
     // Non-fatal, event will get processed later
-    DEBUG ((EFI_D_ERROR, "%a: Failed create event: %r.\r\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Failed create event: %r.\r\n", __FUNCTION__));
     Status = EFI_DEVICE_ERROR;
     goto ErrorExit;
   }
@@ -1581,7 +1581,7 @@ DeviceDiscoveryDxeEntryPoint (
                   NULL
                   );
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "%a: Failed install procotol: %r.\r\n", __FUNCTION__, Status));
+    DEBUG ((DEBUG_ERROR, "%a: Failed install procotol: %r.\r\n", __FUNCTION__, Status));
     goto ErrorExit;
   }
 

--- a/Silicon/NVIDIA/Drivers/EFuseDxe/EFuseDxe.c
+++ b/Silicon/NVIDIA/Drivers/EFuseDxe/EFuseDxe.c
@@ -163,7 +163,7 @@ DeviceDiscoveryNotify (
                  );
       if (EFI_ERROR (Status)) {
         DEBUG ((
-          EFI_D_ERROR,
+          DEBUG_ERROR,
           "%a: Couldn't find Efuse address range\n",
           __FUNCTION__
           ));
@@ -172,7 +172,7 @@ DeviceDiscoveryNotify (
 
       Private = AllocatePool (sizeof (EFUSE_DXE_PRIVATE));
       if (NULL == Private) {
-        DEBUG ((EFI_D_ERROR, "%a: Failed to allocate Memory\r\n", __FUNCTION__));
+        DEBUG ((DEBUG_ERROR, "%a: Failed to allocate Memory\r\n", __FUNCTION__));
         Status = EFI_OUT_OF_RESOURCES;
         return Status;
       }
@@ -192,7 +192,7 @@ DeviceDiscoveryNotify (
                       );
       if (EFI_ERROR (Status)) {
         DEBUG ((
-          EFI_D_ERROR,
+          DEBUG_ERROR,
           "%a, Failed to install protocols: %r\r\n",
           __FUNCTION__,
           Status

--- a/Silicon/NVIDIA/Drivers/EqosDeviceDxe/DtAcpiMacUpdate.c
+++ b/Silicon/NVIDIA/Drivers/EqosDeviceDxe/DtAcpiMacUpdate.c
@@ -48,7 +48,7 @@
 // #define ACPI_DEBUG
 
 #ifdef ACPI_DEBUG
-#define DBG(arg ...)  DEBUG((EFI_D_ERROR,## arg))
+#define DBG(arg ...)  DEBUG((DEBUG_ERROR,## arg))
 #else
 #define DBG(arg ...)
 #endif
@@ -227,7 +227,7 @@ GetEthID (
   // Get NameString ETHx
   Status = AcpiTableProtocol->GetOption (ChildHandle, 1, &DataType, &Buffer, &DataSize);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "[%a:%d] Get NameString failed: %r\n", __FUNCTION__, __LINE__, Status));
+    DEBUG ((DEBUG_ERROR, "[%a:%d] Get NameString failed: %r\n", __FUNCTION__, __LINE__, Status));
     return Status;
   }
 
@@ -239,7 +239,7 @@ GetEthID (
       (AsciiStrnCmp ("ETH", Data, 3) != 0) ||
       (Data[3] > '9') || (Data[3] < '0'))
   {
-    DEBUG ((EFI_D_ERROR, "[%a:%d] The NameString %a is not ETHn\n", __FUNCTION__, __LINE__, Data));
+    DEBUG ((DEBUG_ERROR, "[%a:%d] The NameString %a is not ETHn\n", __FUNCTION__, __LINE__, Data));
     return EFI_INVALID_PARAMETER;
   }
 
@@ -503,7 +503,7 @@ EthMacInit (
   EFI_ACPI_HANDLE         TableHandle;
   UINTN                   i;
 
-  DEBUG ((EFI_D_ERROR, "Updating Ethernet MAC in ACPI DSDT...\n"));
+  DEBUG ((DEBUG_ERROR, "Updating Ethernet MAC in ACPI DSDT...\n"));
 
   //
   // Find the AcpiTable protocol

--- a/Silicon/NVIDIA/Drivers/EqosDeviceDxe/PhyDxeUtil.c
+++ b/Silicon/NVIDIA/Drivers/EqosDeviceDxe/PhyDxeUtil.c
@@ -292,7 +292,7 @@ PhyLinkAdjustEmacConfig (
 
       Status = DeviceDiscoverySetClockFreq (PhyDriver->ControllerHandle, "tx", ClockRate);
       if (EFI_ERROR (Status)) {
-        DEBUG ((EFI_D_ERROR, "%a, Failed to set clock frequency %r\r\n", __FUNCTION__, Status));
+        DEBUG ((DEBUG_ERROR, "%a, Failed to set clock frequency %r\r\n", __FUNCTION__, Status));
         Status = EFI_SUCCESS;
       }
     } else {

--- a/Silicon/NVIDIA/Drivers/FvbDxe/FvbDxe.c
+++ b/Silicon/NVIDIA/Drivers/FvbDxe/FvbDxe.c
@@ -407,7 +407,7 @@ FvbWrite (
                                   );
 
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "%a: FVB write failed. Recovered FVB could be corrupt.\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: FVB write failed. Recovered FVB could be corrupt.\n", __FUNCTION__));
     ASSERT (FALSE);
     Private->BlockIo->ReadBlocks (
                         Private->BlockIo,
@@ -556,7 +556,7 @@ FvbEraseBlocks (
                                    Private->VariablePartition + FvbOffset + (Index * BlockSize)
                                    );
       if (EFI_ERROR (Status)) {
-        DEBUG ((EFI_D_ERROR, "%a: FVB write failed. Recovered FVB could be corrupt.\n", __FUNCTION__));
+        DEBUG ((DEBUG_ERROR, "%a: FVB write failed. Recovered FVB could be corrupt.\n", __FUNCTION__));
         ASSERT (FALSE);
         Private->BlockIo->ReadBlocks (
                             Private->BlockIo,
@@ -679,20 +679,20 @@ ValidateFvHeader (
       (FwVolHeader->Signature != EFI_FVH_SIGNATURE) ||
       (FwVolHeader->FvLength  > FvLength))
   {
-    DEBUG ((EFI_D_INFO, "%a: No Firmware Volume header present\n", __FUNCTION__));
+    DEBUG ((DEBUG_INFO, "%a: No Firmware Volume header present\n", __FUNCTION__));
     return EFI_NOT_FOUND;
   }
 
   // Check the Firmware Volume Guid
   if ( CompareGuid (&FwVolHeader->FileSystemGuid, &gEfiSystemNvDataFvGuid) == FALSE ) {
-    DEBUG ((EFI_D_INFO, "%a: Firmware Volume Guid non-compatible\n", __FUNCTION__));
+    DEBUG ((DEBUG_INFO, "%a: Firmware Volume Guid non-compatible\n", __FUNCTION__));
     return EFI_NOT_FOUND;
   }
 
   // Verify the header checksum
   Checksum = CalculateSum16 ((UINT16 *)FwVolHeader, FwVolHeader->HeaderLength);
   if (Checksum != 0) {
-    DEBUG ((EFI_D_INFO, "%a: FV checksum is invalid (Checksum:0x%X)\n", __FUNCTION__, Checksum));
+    DEBUG ((DEBUG_INFO, "%a: FV checksum is invalid (Checksum:0x%X)\n", __FUNCTION__, Checksum));
     return EFI_NOT_FOUND;
   }
 
@@ -702,14 +702,14 @@ ValidateFvHeader (
   if (!CompareGuid (&VariableStoreHeader->Signature, &gEfiVariableGuid) &&
       !CompareGuid (&VariableStoreHeader->Signature, &gEfiAuthenticatedVariableGuid))
   {
-    DEBUG ((EFI_D_INFO, "%a: Variable Store Guid non-compatible\n", __FUNCTION__));
+    DEBUG ((DEBUG_INFO, "%a: Variable Store Guid non-compatible\n", __FUNCTION__));
     return EFI_NOT_FOUND;
   }
 
   VariableStoreLength = FwVolHeader->FvLength - FwVolHeader->HeaderLength;
 
   if (VariableStoreHeader->Size != VariableStoreLength) {
-    DEBUG ((EFI_D_INFO, "%a: Variable Store Length does not match\n", __FUNCTION__));
+    DEBUG ((DEBUG_INFO, "%a: Variable Store Length does not match\n", __FUNCTION__));
     return EFI_NOT_FOUND;
   }
 
@@ -1230,8 +1230,8 @@ FVBInitialize (
   Status = ValidateFvHeader ((EFI_FIRMWARE_VOLUME_HEADER *)Private->VariablePartition);
 
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_INFO, "%a: The FVB Header is not valid.\n", __FUNCTION__));
-    DEBUG ((EFI_D_INFO, "%a: Installing a correct one for this volume.\n", __FUNCTION__));
+    DEBUG ((DEBUG_INFO, "%a: The FVB Header is not valid.\n", __FUNCTION__));
+    DEBUG ((DEBUG_INFO, "%a: Installing a correct one for this volume.\n", __FUNCTION__));
 
     gBS->SetMem (Private->VariablePartition, Size, 0xFF);
 

--- a/Silicon/NVIDIA/Drivers/FvbNorFlashDxe/FvbDxe.c
+++ b/Silicon/NVIDIA/Drivers/FvbNorFlashDxe/FvbDxe.c
@@ -429,7 +429,7 @@ FvbWrite (
                                         );
 
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "%a: FVB write failed. Recovered FVB could be corrupt.\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: FVB write failed. Recovered FVB could be corrupt.\n", __FUNCTION__));
     ASSERT (FALSE);
     if (Private->PartitionData != NULL) {
       Private->NorFlashProtocol->Read (
@@ -581,7 +581,7 @@ FvbEraseBlocks (
                                           NumOfLba
                                           );
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "%a: FVB write failed. Recovered FVB could be corrupt.\n", __FUNCTION__));
+      DEBUG ((DEBUG_ERROR, "%a: FVB write failed. Recovered FVB could be corrupt.\n", __FUNCTION__));
       ASSERT (FALSE);
       if (Private->PartitionData != NULL) {
         Private->NorFlashProtocol->Read (
@@ -827,20 +827,20 @@ ValidateFvHeader (
       (FwVolHeader->Signature != EFI_FVH_SIGNATURE) ||
       (FwVolHeader->FvLength  > PartitionSize))
   {
-    DEBUG ((EFI_D_INFO, "%a: No Firmware Volume header present\n", __FUNCTION__));
+    DEBUG ((DEBUG_INFO, "%a: No Firmware Volume header present\n", __FUNCTION__));
     return EFI_NOT_FOUND;
   }
 
   // Check the Firmware Volume Guid
   if ( CompareGuid (&FwVolHeader->FileSystemGuid, &gEfiSystemNvDataFvGuid) == FALSE ) {
-    DEBUG ((EFI_D_INFO, "%a: Firmware Volume Guid non-compatible\n", __FUNCTION__));
+    DEBUG ((DEBUG_INFO, "%a: Firmware Volume Guid non-compatible\n", __FUNCTION__));
     return EFI_NOT_FOUND;
   }
 
   // Verify the header checksum
   Checksum = CalculateSum16 ((UINT16 *)FwVolHeader, FwVolHeader->HeaderLength);
   if (Checksum != 0) {
-    DEBUG ((EFI_D_INFO, "%a: FV checksum is invalid (Checksum:0x%X)\n", __FUNCTION__, Checksum));
+    DEBUG ((DEBUG_INFO, "%a: FV checksum is invalid (Checksum:0x%X)\n", __FUNCTION__, Checksum));
     return EFI_NOT_FOUND;
   }
 
@@ -851,14 +851,14 @@ ValidateFvHeader (
     if (!CompareGuid (&VariableStoreHeader->Signature, &gEfiVariableGuid) &&
         !CompareGuid (&VariableStoreHeader->Signature, &gEfiAuthenticatedVariableGuid))
     {
-      DEBUG ((EFI_D_INFO, "%a: Variable Store Guid non-compatible\n", __FUNCTION__));
+      DEBUG ((DEBUG_INFO, "%a: Variable Store Guid non-compatible\n", __FUNCTION__));
       return EFI_NOT_FOUND;
     }
 
     VariableStoreLength = FwVolHeader->FvLength - FwVolHeader->HeaderLength;
 
     if (VariableStoreHeader->Size != VariableStoreLength) {
-      DEBUG ((EFI_D_INFO, "%a: Variable Store Length does not match\n", __FUNCTION__));
+      DEBUG ((DEBUG_INFO, "%a: Variable Store Length does not match\n", __FUNCTION__));
       return EFI_NOT_FOUND;
     }
   }

--- a/Silicon/NVIDIA/Drivers/FvbNorFlashDxe/FvbNorFlashStandaloneMm.c
+++ b/Silicon/NVIDIA/Drivers/FvbNorFlashDxe/FvbNorFlashStandaloneMm.c
@@ -431,7 +431,7 @@ FvbWrite (
                                         );
 
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "%a: FVB write failed. Recovered FVB could be corrupt.\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: FVB write failed. Recovered FVB could be corrupt.\n", __FUNCTION__));
     ASSERT (FALSE);
     if (Private->PartitionData != NULL) {
       Private->NorFlashProtocol->Read (
@@ -583,7 +583,7 @@ FvbEraseBlocks (
                                           NumOfLba
                                           );
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "%a: FVB write failed. Recovered FVB could be corrupt.\n", __FUNCTION__));
+      DEBUG ((DEBUG_ERROR, "%a: FVB write failed. Recovered FVB could be corrupt.\n", __FUNCTION__));
       ASSERT (FALSE);
       if (Private->PartitionData != NULL) {
         Private->NorFlashProtocol->Read (
@@ -837,20 +837,20 @@ ValidateFvHeader (
       (FwVolHeader->Signature != EFI_FVH_SIGNATURE) ||
       (FwVolHeader->FvLength  > PartitionSize))
   {
-    DEBUG ((EFI_D_INFO, "%a: No Firmware Volume header present\n", __FUNCTION__));
+    DEBUG ((DEBUG_INFO, "%a: No Firmware Volume header present\n", __FUNCTION__));
     return EFI_NOT_FOUND;
   }
 
   // Check the Firmware Volume Guid
   if ( CompareGuid (&FwVolHeader->FileSystemGuid, &gEfiSystemNvDataFvGuid) == FALSE ) {
-    DEBUG ((EFI_D_INFO, "%a: Firmware Volume Guid non-compatible\n", __FUNCTION__));
+    DEBUG ((DEBUG_INFO, "%a: Firmware Volume Guid non-compatible\n", __FUNCTION__));
     return EFI_NOT_FOUND;
   }
 
   // Verify the header checksum
   Checksum = CalculateSum16 ((UINT16 *)FwVolHeader, FwVolHeader->HeaderLength);
   if (Checksum != 0) {
-    DEBUG ((EFI_D_INFO, "%a: FV checksum is invalid (Checksum:0x%X)\n", __FUNCTION__, Checksum));
+    DEBUG ((DEBUG_INFO, "%a: FV checksum is invalid (Checksum:0x%X)\n", __FUNCTION__, Checksum));
     return EFI_NOT_FOUND;
   }
 
@@ -861,14 +861,14 @@ ValidateFvHeader (
     if (!CompareGuid (&VariableStoreHeader->Signature, &gEfiVariableGuid) &&
         !CompareGuid (&VariableStoreHeader->Signature, &gEfiAuthenticatedVariableGuid))
     {
-      DEBUG ((EFI_D_INFO, "%a: Variable Store Guid non-compatible\n", __FUNCTION__));
+      DEBUG ((DEBUG_INFO, "%a: Variable Store Guid non-compatible\n", __FUNCTION__));
       return EFI_NOT_FOUND;
     }
 
     VariableStoreLength = FwVolHeader->FvLength - FwVolHeader->HeaderLength;
 
     if (VariableStoreHeader->Size != VariableStoreLength) {
-      DEBUG ((EFI_D_INFO, "%a: Variable Store Length does not match\n", __FUNCTION__));
+      DEBUG ((DEBUG_INFO, "%a: Variable Store Length does not match\n", __FUNCTION__));
       return EFI_NOT_FOUND;
     }
   }

--- a/Silicon/NVIDIA/Drivers/I2cExpanderGpio/I2cExpanderGpio.c
+++ b/Silicon/NVIDIA/Drivers/I2cExpanderGpio/I2cExpanderGpio.c
@@ -129,7 +129,7 @@ GetGpioState (
   RequestData.Operation[1].Flags         = I2C_FLAG_READ;
   Status                                 = I2cIo->QueueRequest (I2cIo, 0, NULL, RequestPacket, NULL);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "%a: Failed to get input register: %r.\r\n", __FUNCTION__, Status));
+    DEBUG ((DEBUG_ERROR, "%a: Failed to get input register: %r.\r\n", __FUNCTION__, Status));
     return EFI_DEVICE_ERROR;
   }
 
@@ -187,7 +187,7 @@ SetGpioState (
   RequestData.Operation[1].Flags         = I2C_FLAG_READ;
   Status                                 = I2cIo->QueueRequest (I2cIo, 0, NULL, RequestPacket, NULL);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "%a: Failed to get config register: %r.\r\n", __FUNCTION__, Status));
+    DEBUG ((DEBUG_ERROR, "%a: Failed to get config register: %r.\r\n", __FUNCTION__, Status));
     return EFI_DEVICE_ERROR;
   }
 
@@ -201,7 +201,7 @@ SetGpioState (
   RequestData.Operation[1].Flags         = I2C_FLAG_READ;
   Status                                 = I2cIo->QueueRequest (I2cIo, 0, NULL, RequestPacket, NULL);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "%a: Failed to get config register: %r.\r\n", __FUNCTION__, Status));
+    DEBUG ((DEBUG_ERROR, "%a: Failed to get config register: %r.\r\n", __FUNCTION__, Status));
     return EFI_DEVICE_ERROR;
   }
 
@@ -235,7 +235,7 @@ SetGpioState (
   RequestData.Operation[0].Flags         = 0;
   Status                                 = I2cIo->QueueRequest (I2cIo, 0, NULL, RequestPacket, NULL);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "%a: Failed to set config register: %r.\r\n", __FUNCTION__, Status));
+    DEBUG ((DEBUG_ERROR, "%a: Failed to set config register: %r.\r\n", __FUNCTION__, Status));
     return EFI_DEVICE_ERROR;
   }
 
@@ -248,7 +248,7 @@ SetGpioState (
     RequestData.Operation[0].Flags         = 0;
     Status                                 = I2cIo->QueueRequest (I2cIo, 0, NULL, RequestPacket, NULL);
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "%a: Failed to set output register: %r.\r\n", __FUNCTION__, Status));
+      DEBUG ((DEBUG_ERROR, "%a: Failed to set output register: %r.\r\n", __FUNCTION__, Status));
       return EFI_DEVICE_ERROR;
     }
   }
@@ -304,7 +304,7 @@ GetGpioMode (
   RequestData.Operation[1].Flags         = I2C_FLAG_READ;
   Status                                 = I2cIo->QueueRequest (I2cIo, 0, NULL, RequestPacket, NULL);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "%a: Failed to get config register: %r.\r\n", __FUNCTION__, Status));
+    DEBUG ((DEBUG_ERROR, "%a: Failed to get config register: %r.\r\n", __FUNCTION__, Status));
     return EFI_DEVICE_ERROR;
   }
 
@@ -318,7 +318,7 @@ GetGpioMode (
   RequestData.Operation[1].Flags         = I2C_FLAG_READ;
   Status                                 = I2cIo->QueueRequest (I2cIo, 0, NULL, RequestPacket, NULL);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "%a: Failed to get config register: %r.\r\n", __FUNCTION__, Status));
+    DEBUG ((DEBUG_ERROR, "%a: Failed to get config register: %r.\r\n", __FUNCTION__, Status));
     return EFI_DEVICE_ERROR;
   }
 
@@ -466,7 +466,7 @@ InitializeI2cExpanderGpio (
                           &mI2cExpanderData.I2cIoSearchToken
                           );
       if (I2cIoReadyEvent == NULL) {
-        DEBUG ((EFI_D_ERROR, "%a, Failed to create I2cIo notification event\r\n", __FUNCTION__));
+        DEBUG ((DEBUG_ERROR, "%a, Failed to create I2cIo notification event\r\n", __FUNCTION__));
         Status = EFI_OUT_OF_RESOURCES;
       }
     } else {

--- a/Silicon/NVIDIA/Drivers/MmCommunicateFfaDxe/MmCommunication.c
+++ b/Silicon/NVIDIA/Drivers/MmCommunicateFfaDxe/MmCommunication.c
@@ -607,13 +607,13 @@ FfaAllocateAndMapRxTxBuffers (
 
   Status = gBS->AllocatePages (AllocateAnyPages, EfiBootServicesData, pages, rx);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "%a: RX buffer allocation failed\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: RX buffer allocation failed\n", __FUNCTION__));
     goto out;
   }
 
   Status = gBS->AllocatePages (AllocateAnyPages, EfiBootServicesData, pages, tx);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "%a: TX buffer allocation failed\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: TX buffer allocation failed\n", __FUNCTION__));
     goto out_rx;
   }
 
@@ -626,7 +626,7 @@ FfaAllocateAndMapRxTxBuffers (
 
   if (ArmSmcArgs.Arg2 != ARM_FFA_SPM_RET_SUCCESS) {
     DEBUG ((
-      EFI_D_ERROR,
+      DEBUG_ERROR,
       "%a: ARM_SVC_ID_FFA_RXTX_MAP failed: 0x%x\n",
       __FUNCTION__,
       ArmSmcArgs.Arg2
@@ -675,7 +675,7 @@ FfaFreeRxTxBuffers (
 
   if (ArmSmcArgs.Arg2 != ARM_FFA_SPM_RET_SUCCESS) {
     DEBUG ((
-      EFI_D_ERROR,
+      DEBUG_ERROR,
       "%a: ARM_SVC_ID_FFA_RXTX_UNMAP failed: 0x%x\n",
       __FUNCTION__,
       ArmSmcArgs.Arg2
@@ -771,7 +771,7 @@ GetStmmVmId (
   /* One SP should have been found */
   if (ArmSmcArgs.Arg2 != 1) {
     DEBUG ((
-      EFI_D_ERROR,
+      DEBUG_ERROR,
       "%a: ARM_SVC_ID_FFA_PARTITION_INFO_GET failed: 0x%x\n",
       __FUNCTION__,
       ArmSmcArgs.Arg2

--- a/Silicon/NVIDIA/Drivers/NorFlashDxe/NorFlashDxe.c
+++ b/Silicon/NVIDIA/Drivers/NorFlashDxe/NorFlashDxe.c
@@ -73,7 +73,7 @@ ReadNorFlashRegister (
 
   Status = Private->QspiController->PerformTransaction (Private->QspiController, &Packet);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "%a: Could not read NOR flash register.\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Could not read NOR flash register.\n", __FUNCTION__));
   }
 
   return Status;
@@ -110,7 +110,7 @@ WaitNorFlashWriteComplete (
     if (Count == NOR_SR1_WIP_RETRY_CNT) {
       Count = 0;
       if (TimeOutMessage == FALSE) {
-        DEBUG ((EFI_D_ERROR, "%a: NOR flash write transactions slower than usual.\n", __FUNCTION__));
+        DEBUG ((DEBUG_ERROR, "%a: NOR flash write transactions slower than usual.\n", __FUNCTION__));
         TimeOutMessage = TRUE;
       }
     }
@@ -120,14 +120,14 @@ WaitNorFlashWriteComplete (
     // Read WIP status
     Status = ReadNorFlashRegister (Private, &RegCmd, sizeof (RegCmd), &Resp);
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "%a: Could not read NOR flash status 1 register.\n", __FUNCTION__));
+      DEBUG ((DEBUG_ERROR, "%a: Could not read NOR flash status 1 register.\n", __FUNCTION__));
       return Status;
     }
 
     Count++;
   } while ((Resp & NOR_SR1_WIP_BMSK) != 0);
 
-  DEBUG ((EFI_D_INFO, "%a: NOR flash write complete.\n", __FUNCTION__));
+  DEBUG ((DEBUG_INFO, "%a: NOR flash write complete.\n", __FUNCTION__));
   return Status;
 }
 
@@ -176,7 +176,7 @@ ConfigureNorFlashWriteEnLatch (
     if (Count == NOR_SR1_WEL_RETRY_CNT) {
       Count = 0;
       if (TimeOutMessage == FALSE) {
-        DEBUG ((EFI_D_ERROR, "%a: NOR flash write enable latch slower than usual.\n", __FUNCTION__));
+        DEBUG ((DEBUG_ERROR, "%a: NOR flash write enable latch slower than usual.\n", __FUNCTION__));
         TimeOutMessage = TRUE;
       }
     }
@@ -184,7 +184,7 @@ ConfigureNorFlashWriteEnLatch (
     // Configure WREN
     Status = Private->QspiController->PerformTransaction (Private->QspiController, &Packet);
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "%a: Could not program WREN latch.\n", __FUNCTION__));
+      DEBUG ((DEBUG_ERROR, "%a: Could not program WREN latch.\n", __FUNCTION__));
       return Status;
     }
 
@@ -193,14 +193,14 @@ ConfigureNorFlashWriteEnLatch (
     // Read WREN status
     Status = ReadNorFlashRegister (Private, &RegCmd, sizeof (RegCmd), &Resp);
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "%a: Could not read NOR flash status 1 register.\n", __FUNCTION__));
+      DEBUG ((DEBUG_ERROR, "%a: Could not read NOR flash status 1 register.\n", __FUNCTION__));
       return Status;
     }
 
     Count++;
   } while ((Resp & NOR_SR1_WEL_BMSK) != Cmp);
 
-  DEBUG ((EFI_D_INFO, "%a: NOR flash WREN %s.\n", __FUNCTION__, Enable ? L"enabled" : L"disabled"));
+  DEBUG ((DEBUG_INFO, "%a: NOR flash WREN %s.\n", __FUNCTION__, Enable ? L"enabled" : L"disabled"));
   return Status;
 }
 
@@ -270,14 +270,14 @@ ReadNorFlashSFDP (
 
   Status = Private->QspiController->PerformTransaction (Private->QspiController, &Packet);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "%a: Could not read NOR flash's SFDP header.\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Could not read NOR flash's SFDP header.\n", __FUNCTION__));
     goto ErrorExit;
   }
 
   // Verify the read SFDP signature
   SFDPSignature = NOR_SFDP_SIGNATURE;
   if (0 != CompareMem (&SFDPHeader.SFDPSignature, &SFDPSignature, sizeof (SFDPHeader.SFDPSignature))) {
-    DEBUG ((EFI_D_ERROR, "%a: NOR flash's SFDP signature invalid.\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: NOR flash's SFDP signature invalid.\n", __FUNCTION__));
     Status = EFI_NOT_FOUND;
     goto ErrorExit;
   }
@@ -306,7 +306,7 @@ ReadNorFlashSFDP (
 
   Status = Private->QspiController->PerformTransaction (Private->QspiController, &Packet);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "%a: Could not read NOR flash's SFDP parameter table headers.\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Could not read NOR flash's SFDP parameter table headers.\n", __FUNCTION__));
     goto ErrorExit;
   }
 
@@ -320,7 +320,7 @@ ReadNorFlashSFDP (
   }
 
   if (Count < 0) {
-    DEBUG ((EFI_D_ERROR, "%a: Could not find compatible NOR flash's SFDP parameter table header.\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Could not find compatible NOR flash's SFDP parameter table header.\n", __FUNCTION__));
     Status = EFI_UNSUPPORTED;
     goto ErrorExit;
   }
@@ -352,7 +352,7 @@ ReadNorFlashSFDP (
 
   Status = Private->QspiController->PerformTransaction (Private->QspiController, &Packet);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "%a: Could not read NOR flash's SFDP parameters.\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Could not read NOR flash's SFDP parameters.\n", __FUNCTION__));
     goto ErrorExit;
   }
 
@@ -366,7 +366,7 @@ ReadNorFlashSFDP (
   }
 
   if (Count < 0) {
-    DEBUG ((EFI_D_ERROR, "%a: Could not find compatible NOR flash's SFDP 4 byte instruction parameter table header.\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Could not find compatible NOR flash's SFDP 4 byte instruction parameter table header.\n", __FUNCTION__));
     Status = EFI_UNSUPPORTED;
     goto ErrorExit;
   }
@@ -398,7 +398,7 @@ ReadNorFlashSFDP (
 
   Status = Private->QspiController->PerformTransaction (Private->QspiController, &Packet);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "%a: Could not read NOR flash's SFDP 4 byte instruction parameters.\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Could not read NOR flash's SFDP 4 byte instruction parameters.\n", __FUNCTION__));
     goto ErrorExit;
   }
 
@@ -406,7 +406,7 @@ ReadNorFlashSFDP (
   if ((SFDPParam4ByteInstructionTbl->ReadCmd0C == FALSE) ||
       (SFDPParam4ByteInstructionTbl->ReadCmd13 == FALSE))
   {
-    DEBUG ((EFI_D_ERROR, "%a: NOR flash's single bit Read unsupported.\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: NOR flash's single bit Read unsupported.\n", __FUNCTION__));
     Status = EFI_UNSUPPORTED;
     goto ErrorExit;
   }
@@ -419,7 +419,7 @@ ReadNorFlashSFDP (
 
   // Page write has to be supported
   if (SFDPParam4ByteInstructionTbl->WriteCmd12 == FALSE) {
-    DEBUG ((EFI_D_ERROR, "%a: NOR flash's single bit Write unsupported.\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: NOR flash's single bit Write unsupported.\n", __FUNCTION__));
     Status = EFI_UNSUPPORTED;
     goto ErrorExit;
   }
@@ -430,7 +430,7 @@ ReadNorFlashSFDP (
   if (MemoryDensity & BIT31) {
     MemoryDensity &= ~BIT31;
     if (MemoryDensity < 32) {
-      DEBUG ((EFI_D_ERROR, "%a: NOR flash's memory density unsupported.\n", __FUNCTION__));
+      DEBUG ((DEBUG_ERROR, "%a: NOR flash's memory density unsupported.\n", __FUNCTION__));
       Status = EFI_UNSUPPORTED;
       goto ErrorExit;
     }
@@ -465,7 +465,7 @@ ReadNorFlashSFDP (
     }
 
     if (Count < 0) {
-      DEBUG ((EFI_D_ERROR, "%a: Could not find compatible NOR flash's SFDP sector parameter table header.\n", __FUNCTION__));
+      DEBUG ((DEBUG_ERROR, "%a: Could not find compatible NOR flash's SFDP sector parameter table header.\n", __FUNCTION__));
       Status = EFI_UNSUPPORTED;
       goto ErrorExit;
     }
@@ -497,7 +497,7 @@ ReadNorFlashSFDP (
 
     Status = Private->QspiController->PerformTransaction (Private->QspiController, &Packet);
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "%a: Could not read NOR flash's SFDP sector parameters.\n", __FUNCTION__));
+      DEBUG ((DEBUG_ERROR, "%a: Could not read NOR flash's SFDP sector parameters.\n", __FUNCTION__));
       goto ErrorExit;
     }
 
@@ -518,7 +518,7 @@ ReadNorFlashSFDP (
     }
 
     if (Count >=  SFDPParamSectorTblHeader->ParamTblLen) {
-      DEBUG ((EFI_D_ERROR, "%a: Could not find compatible NOR flash's SFDP sector parameter mapping table.\n", __FUNCTION__));
+      DEBUG ((DEBUG_ERROR, "%a: Could not find compatible NOR flash's SFDP sector parameter mapping table.\n", __FUNCTION__));
       Status = EFI_UNSUPPORTED;
       goto ErrorExit;
     }
@@ -544,7 +544,7 @@ ReadNorFlashSFDP (
     }
 
     if (Count >=  NOR_SFDP_ERASE_COUNT) {
-      DEBUG ((EFI_D_ERROR, "%a: Could not find compatible NOR flash's SFDP sector parameter erase table.\n", __FUNCTION__));
+      DEBUG ((DEBUG_ERROR, "%a: Could not find compatible NOR flash's SFDP sector parameter erase table.\n", __FUNCTION__));
       Status = EFI_UNSUPPORTED;
       goto ErrorExit;
     }
@@ -559,7 +559,7 @@ ReadNorFlashSFDP (
     }
 
     if (Count >=  NOR_SFDP_ERASE_COUNT) {
-      DEBUG ((EFI_D_ERROR, "%a: Could not find compatible NOR flash's SFDP first sector parameter erase table.\n", __FUNCTION__));
+      DEBUG ((DEBUG_ERROR, "%a: Could not find compatible NOR flash's SFDP first sector parameter erase table.\n", __FUNCTION__));
       Status = EFI_UNSUPPORTED;
       goto ErrorExit;
     }
@@ -579,13 +579,13 @@ ReadNorFlashSFDP (
   }
 
   if (Count >=  NOR_SFDP_ERASE_COUNT) {
-    DEBUG ((EFI_D_ERROR, "%a: Could not find compatible NOR flash's uniform block size in SFDP sector parameter erase table.\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Could not find compatible NOR flash's uniform block size in SFDP sector parameter erase table.\n", __FUNCTION__));
     Status = EFI_UNSUPPORTED;
     goto ErrorExit;
   }
 
   if (!(SFDPParam4ByteInstructionTbl->EraseTypeSupported & (1 << Count))) {
-    DEBUG ((EFI_D_ERROR, "%a: Could not find compatible NOR flash's uniform erase table supported in SFDP.\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Could not find compatible NOR flash's uniform erase table supported in SFDP.\n", __FUNCTION__));
     Status = EFI_UNSUPPORTED;
     goto ErrorExit;
   }
@@ -604,13 +604,13 @@ ReadNorFlashSFDP (
     }
 
     if (Count >=  NOR_SFDP_ERASE_COUNT) {
-      DEBUG ((EFI_D_ERROR, "%a: Could not find compatible NOR flash's hybrid block size in SFDP sector parameter erase table.\n", __FUNCTION__));
+      DEBUG ((DEBUG_ERROR, "%a: Could not find compatible NOR flash's hybrid block size in SFDP sector parameter erase table.\n", __FUNCTION__));
       Status = EFI_UNSUPPORTED;
       goto ErrorExit;
     }
 
     if (!(SFDPParam4ByteInstructionTbl->EraseTypeSupported & (1 << Count))) {
-      DEBUG ((EFI_D_ERROR, "%a: Could not find compatible NOR flash's hybrid erase table supported in SFDP.\n", __FUNCTION__));
+      DEBUG ((DEBUG_ERROR, "%a: Could not find compatible NOR flash's hybrid erase table supported in SFDP.\n", __FUNCTION__));
       Status = EFI_UNSUPPORTED;
       goto ErrorExit;
     }
@@ -779,11 +779,11 @@ NorFlashRead (
 
   Status = Private->QspiController->PerformTransaction (Private->QspiController, &Packet);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "%a: Could not read data from NOR flash.\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Could not read data from NOR flash.\n", __FUNCTION__));
     goto ErrorExit;
   }
 
-  DEBUG ((EFI_D_INFO, "%a: Successfully read data from NOR flash.\n", __FUNCTION__));
+  DEBUG ((DEBUG_INFO, "%a: Successfully read data from NOR flash.\n", __FUNCTION__));
 
 ErrorExit:
 
@@ -912,7 +912,7 @@ NorFlashErase (
                );
     if (EFI_ERROR (Status)) {
       DEBUG ((
-        EFI_D_ERROR,
+        DEBUG_ERROR,
         "%a: Failed hybrid erase: %r\n",
         __FUNCTION__,
         Status
@@ -927,7 +927,7 @@ NorFlashErase (
   for (Block = Lba; Block < (Lba + NumLba); Block++) {
     Status = ConfigureNorFlashWriteEnLatch (Private, TRUE);
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "%a: Could not enable NOR flash WREN.\n", __FUNCTION__));
+      DEBUG ((DEBUG_ERROR, "%a: Could not enable NOR flash WREN.\n", __FUNCTION__));
       goto ErrorExit;
     }
 
@@ -948,24 +948,24 @@ NorFlashErase (
 
     Status = Private->QspiController->PerformTransaction (Private->QspiController, &Packet);
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "%a: Could not erase data from NOR flash.\n", __FUNCTION__));
+      DEBUG ((DEBUG_ERROR, "%a: Could not erase data from NOR flash.\n", __FUNCTION__));
       goto ErrorExit;
     }
 
     Status = WaitNorFlashWriteComplete (Private);
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "%a: Could not complete NOR flash write.\n", __FUNCTION__));
+      DEBUG ((DEBUG_ERROR, "%a: Could not complete NOR flash write.\n", __FUNCTION__));
       goto ErrorExit;
     }
 
     Status = ConfigureNorFlashWriteEnLatch (Private, FALSE);
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "%a: Could not enable NOR flash WREN.\n", __FUNCTION__));
+      DEBUG ((DEBUG_ERROR, "%a: Could not enable NOR flash WREN.\n", __FUNCTION__));
       goto ErrorExit;
     }
   }
 
-  DEBUG ((EFI_D_INFO, "%a: Successfully erased data from NOR flash.\n", __FUNCTION__));
+  DEBUG ((DEBUG_INFO, "%a: Successfully erased data from NOR flash.\n", __FUNCTION__));
 
 ErrorExit:
 
@@ -1094,7 +1094,7 @@ NorFlashWriteSinglePage (
   ZeroMem (Private->CommandBuffer, CmdSize + Size);
   Status = ConfigureNorFlashWriteEnLatch (Private, TRUE);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "%a: Could not enable NOR flash WREN.\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Could not enable NOR flash WREN.\n", __FUNCTION__));
     goto ErrorExit;
   }
 
@@ -1115,23 +1115,23 @@ NorFlashWriteSinglePage (
 
   Status = Private->QspiController->PerformTransaction (Private->QspiController, &Packet);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "%a: Could not write data to NOR flash.\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Could not write data to NOR flash.\n", __FUNCTION__));
     goto ErrorExit;
   }
 
   Status = WaitNorFlashWriteComplete (Private);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "%a: Could not complete NOR flash write.\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Could not complete NOR flash write.\n", __FUNCTION__));
     goto ErrorExit;
   }
 
   Status = ConfigureNorFlashWriteEnLatch (Private, FALSE);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "%a: Could not disable NOR flash WREN.\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Could not disable NOR flash WREN.\n", __FUNCTION__));
     goto ErrorExit;
   }
 
-  DEBUG ((EFI_D_INFO, "%a: Successfully wrote data to NOR flash.\n", __FUNCTION__));
+  DEBUG ((DEBUG_INFO, "%a: Successfully wrote data to NOR flash.\n", __FUNCTION__));
 
 ErrorExit:
 
@@ -1190,7 +1190,7 @@ NorFlashWrite (
 
     Status = NorFlashWriteSinglePage (This, Offset, BytesToWrite, Buffer);
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "%a: Could not write data to NOR flash.\n", __FUNCTION__));
+      DEBUG ((DEBUG_ERROR, "%a: Could not write data to NOR flash.\n", __FUNCTION__));
       return Status;
     }
 
@@ -1199,7 +1199,7 @@ NorFlashWrite (
     Size   -= BytesToWrite;
   }
 
-  DEBUG ((EFI_D_INFO, "%a: Successfully wrote data to NOR flash.\n", __FUNCTION__));
+  DEBUG ((DEBUG_INFO, "%a: Successfully wrote data to NOR flash.\n", __FUNCTION__));
 
   return Status;
 }
@@ -1721,7 +1721,7 @@ NorFlashDxeDriverBindingStart (
                   &Private->VirtualAddrChangeEvent
                   );
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "%a: Failed to create virtual address callback event\r\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Failed to create virtual address callback event\r\n", __FUNCTION__));
     goto ErrorExit;
   }
 
@@ -1733,7 +1733,7 @@ NorFlashDxeDriverBindingStart (
                   NULL
                   );
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "%a: Failed to install callerid protocol\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Failed to install callerid protocol\n", __FUNCTION__));
     goto ErrorExit;
   }
 

--- a/Silicon/NVIDIA/Drivers/NorFlashDxe/NorFlashStandaloneMm.c
+++ b/Silicon/NVIDIA/Drivers/NorFlashDxe/NorFlashStandaloneMm.c
@@ -79,7 +79,7 @@ ReadNorFlashRegister (
 
   Status = QSPIPERFORMTRANSACTION (&Packet);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "%a: Could not read NOR flash register.\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Could not read NOR flash register.\n", __FUNCTION__));
   }
 
   return Status;
@@ -116,7 +116,7 @@ WaitNorFlashWriteComplete (
     if (Count == NOR_SR1_WIP_RETRY_CNT) {
       Count = 0;
       if (TimeOutMessage == FALSE) {
-        DEBUG ((EFI_D_ERROR, "%a: NOR flash write transactions slower than usual.\n", __FUNCTION__));
+        DEBUG ((DEBUG_ERROR, "%a: NOR flash write transactions slower than usual.\n", __FUNCTION__));
         TimeOutMessage = TRUE;
       }
     }
@@ -126,14 +126,14 @@ WaitNorFlashWriteComplete (
     // Read WIP status
     Status = ReadNorFlashRegister (Private, &RegCmd, sizeof (RegCmd), &Resp);
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "%a: Could not read NOR flash status 1 register.\n", __FUNCTION__));
+      DEBUG ((DEBUG_ERROR, "%a: Could not read NOR flash status 1 register.\n", __FUNCTION__));
       return Status;
     }
 
     Count++;
   } while ((Resp & NOR_SR1_WIP_BMSK) != 0);
 
-  DEBUG ((EFI_D_INFO, "%a: NOR flash write complete.\n", __FUNCTION__));
+  DEBUG ((DEBUG_INFO, "%a: NOR flash write complete.\n", __FUNCTION__));
   return Status;
 }
 
@@ -182,7 +182,7 @@ ConfigureNorFlashWriteEnLatch (
     if (Count == NOR_SR1_WEL_RETRY_CNT) {
       Count = 0;
       if (TimeOutMessage == FALSE) {
-        DEBUG ((EFI_D_ERROR, "%a: NOR flash write enable latch slower than usual.\n", __FUNCTION__));
+        DEBUG ((DEBUG_ERROR, "%a: NOR flash write enable latch slower than usual.\n", __FUNCTION__));
         TimeOutMessage = TRUE;
       }
     }
@@ -190,7 +190,7 @@ ConfigureNorFlashWriteEnLatch (
     // Configure WREN
     Status = QSPIPERFORMTRANSACTION (&Packet);
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "%a: Could not program WREN latch.\n", __FUNCTION__));
+      DEBUG ((DEBUG_ERROR, "%a: Could not program WREN latch.\n", __FUNCTION__));
       return Status;
     }
 
@@ -199,14 +199,14 @@ ConfigureNorFlashWriteEnLatch (
     // Read WREN status
     Status = ReadNorFlashRegister (Private, &RegCmd, sizeof (RegCmd), &Resp);
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "%a: Could not read NOR flash status 1 register.\n", __FUNCTION__));
+      DEBUG ((DEBUG_ERROR, "%a: Could not read NOR flash status 1 register.\n", __FUNCTION__));
       return Status;
     }
 
     Count++;
   } while ((Resp & NOR_SR1_WEL_BMSK) != Cmp);
 
-  DEBUG ((EFI_D_INFO, "%a: NOR flash WREN %s.\n", __FUNCTION__, Enable ? L"enabled" : L"disabled"));
+  DEBUG ((DEBUG_INFO, "%a: NOR flash WREN %s.\n", __FUNCTION__, Enable ? L"enabled" : L"disabled"));
   return Status;
 }
 
@@ -276,14 +276,14 @@ ReadNorFlashSFDP (
 
   Status = QSPIPERFORMTRANSACTION (&Packet);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "%a: Could not read NOR flash's SFDP header.\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Could not read NOR flash's SFDP header.\n", __FUNCTION__));
     goto ErrorExit;
   }
 
   // Verify the read SFDP signature
   SFDPSignature = NOR_SFDP_SIGNATURE;
   if (0 != CompareMem (&SFDPHeader.SFDPSignature, &SFDPSignature, sizeof (SFDPHeader.SFDPSignature))) {
-    DEBUG ((EFI_D_ERROR, "%a: NOR flash's SFDP signature invalid.\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: NOR flash's SFDP signature invalid.\n", __FUNCTION__));
     Status = EFI_NOT_FOUND;
     goto ErrorExit;
   }
@@ -312,7 +312,7 @@ ReadNorFlashSFDP (
 
   Status = QSPIPERFORMTRANSACTION (&Packet);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "%a: Could not read NOR flash's SFDP parameter table headers.\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Could not read NOR flash's SFDP parameter table headers.\n", __FUNCTION__));
     goto ErrorExit;
   }
 
@@ -326,7 +326,7 @@ ReadNorFlashSFDP (
   }
 
   if (Count < 0) {
-    DEBUG ((EFI_D_ERROR, "%a: Could not find compatible NOR flash's SFDP parameter table header.\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Could not find compatible NOR flash's SFDP parameter table header.\n", __FUNCTION__));
     Status = EFI_UNSUPPORTED;
     goto ErrorExit;
   }
@@ -358,7 +358,7 @@ ReadNorFlashSFDP (
 
   Status = QSPIPERFORMTRANSACTION (&Packet);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "%a: Could not read NOR flash's SFDP parameters.\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Could not read NOR flash's SFDP parameters.\n", __FUNCTION__));
     goto ErrorExit;
   }
 
@@ -372,7 +372,7 @@ ReadNorFlashSFDP (
   }
 
   if (Count < 0) {
-    DEBUG ((EFI_D_ERROR, "%a: Could not find compatible NOR flash's SFDP 4 byte instruction parameter table header.\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Could not find compatible NOR flash's SFDP 4 byte instruction parameter table header.\n", __FUNCTION__));
     Status = EFI_UNSUPPORTED;
     goto ErrorExit;
   }
@@ -404,14 +404,14 @@ ReadNorFlashSFDP (
 
   Status = QSPIPERFORMTRANSACTION (&Packet);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "%a: Could not read NOR flash's SFDP 4 byte instruction parameters.\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Could not read NOR flash's SFDP 4 byte instruction parameters.\n", __FUNCTION__));
     goto ErrorExit;
   }
 
   if ((SFDPParam4ByteInstructionTbl->ReadCmd0C == FALSE) ||
       (SFDPParam4ByteInstructionTbl->WriteCmd12 == FALSE))
   {
-    DEBUG ((EFI_D_ERROR, "%a: NOR flash's single bit RW unsupported.\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: NOR flash's single bit RW unsupported.\n", __FUNCTION__));
     Status = EFI_UNSUPPORTED;
     goto ErrorExit;
   }
@@ -422,7 +422,7 @@ ReadNorFlashSFDP (
   if (MemoryDensity & BIT31) {
     MemoryDensity &= ~BIT31;
     if (MemoryDensity < 32) {
-      DEBUG ((EFI_D_ERROR, "%a: NOR flash's memory density unsupported.\n", __FUNCTION__));
+      DEBUG ((DEBUG_ERROR, "%a: NOR flash's memory density unsupported.\n", __FUNCTION__));
       Status = EFI_UNSUPPORTED;
       goto ErrorExit;
     }
@@ -457,7 +457,7 @@ ReadNorFlashSFDP (
     }
 
     if (Count < 0) {
-      DEBUG ((EFI_D_ERROR, "%a: Could not find compatible NOR flash's SFDP sector parameter table header.\n", __FUNCTION__));
+      DEBUG ((DEBUG_ERROR, "%a: Could not find compatible NOR flash's SFDP sector parameter table header.\n", __FUNCTION__));
       Status = EFI_UNSUPPORTED;
       goto ErrorExit;
     }
@@ -489,7 +489,7 @@ ReadNorFlashSFDP (
 
     Status = QSPIPERFORMTRANSACTION (&Packet);
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "%a: Could not read NOR flash's SFDP sector parameters.\n", __FUNCTION__));
+      DEBUG ((DEBUG_ERROR, "%a: Could not read NOR flash's SFDP sector parameters.\n", __FUNCTION__));
       goto ErrorExit;
     }
 
@@ -510,7 +510,7 @@ ReadNorFlashSFDP (
     }
 
     if (Count >=  SFDPParamSectorTblHeader->ParamTblLen) {
-      DEBUG ((EFI_D_ERROR, "%a: Could not find compatible NOR flash's SFDP sector parameter mapping table.\n", __FUNCTION__));
+      DEBUG ((DEBUG_ERROR, "%a: Could not find compatible NOR flash's SFDP sector parameter mapping table.\n", __FUNCTION__));
       Status = EFI_UNSUPPORTED;
       goto ErrorExit;
     }
@@ -536,7 +536,7 @@ ReadNorFlashSFDP (
     }
 
     if (Count >=  NOR_SFDP_ERASE_COUNT) {
-      DEBUG ((EFI_D_ERROR, "%a: Could not find compatible NOR flash's SFDP sector parameter erase table.\n", __FUNCTION__));
+      DEBUG ((DEBUG_ERROR, "%a: Could not find compatible NOR flash's SFDP sector parameter erase table.\n", __FUNCTION__));
       Status = EFI_UNSUPPORTED;
       goto ErrorExit;
     }
@@ -551,7 +551,7 @@ ReadNorFlashSFDP (
     }
 
     if (Count >=  NOR_SFDP_ERASE_COUNT) {
-      DEBUG ((EFI_D_ERROR, "%a: Could not find compatible NOR flash's SFDP first sector parameter erase table.\n", __FUNCTION__));
+      DEBUG ((DEBUG_ERROR, "%a: Could not find compatible NOR flash's SFDP first sector parameter erase table.\n", __FUNCTION__));
       Status = EFI_UNSUPPORTED;
       goto ErrorExit;
     }
@@ -571,13 +571,13 @@ ReadNorFlashSFDP (
   }
 
   if (Count >=  NOR_SFDP_ERASE_COUNT) {
-    DEBUG ((EFI_D_ERROR, "%a: Could not find compatible NOR flash's uniform block size in SFDP sector parameter erase table.\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Could not find compatible NOR flash's uniform block size in SFDP sector parameter erase table.\n", __FUNCTION__));
     Status = EFI_UNSUPPORTED;
     goto ErrorExit;
   }
 
   if (!(SFDPParam4ByteInstructionTbl->EraseTypeSupported & (1 << Count))) {
-    DEBUG ((EFI_D_ERROR, "%a: Could not find compatible NOR flash's uniform erase table supported in SFDP.\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Could not find compatible NOR flash's uniform erase table supported in SFDP.\n", __FUNCTION__));
     Status = EFI_UNSUPPORTED;
     goto ErrorExit;
   }
@@ -596,13 +596,13 @@ ReadNorFlashSFDP (
     }
 
     if (Count >=  NOR_SFDP_ERASE_COUNT) {
-      DEBUG ((EFI_D_ERROR, "%a: Could not find compatible NOR flash's hybrid block size in SFDP sector parameter erase table.\n", __FUNCTION__));
+      DEBUG ((DEBUG_ERROR, "%a: Could not find compatible NOR flash's hybrid block size in SFDP sector parameter erase table.\n", __FUNCTION__));
       Status = EFI_UNSUPPORTED;
       goto ErrorExit;
     }
 
     if (!(SFDPParam4ByteInstructionTbl->EraseTypeSupported & (1 << Count))) {
-      DEBUG ((EFI_D_ERROR, "%a: Could not find compatible NOR flash's hybrid erase table supported in SFDP.\n", __FUNCTION__));
+      DEBUG ((DEBUG_ERROR, "%a: Could not find compatible NOR flash's hybrid erase table supported in SFDP.\n", __FUNCTION__));
       Status = EFI_UNSUPPORTED;
       goto ErrorExit;
     }
@@ -745,11 +745,11 @@ NorFlashRead (
 
   Status = QSPIPERFORMTRANSACTION (&Packet);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "%a: Could not read data from NOR flash.\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Could not read data from NOR flash.\n", __FUNCTION__));
     goto ErrorExit;
   }
 
-  DEBUG ((EFI_D_INFO, "%a: Successfully read data from NOR flash.\n", __FUNCTION__));
+  DEBUG ((DEBUG_INFO, "%a: Successfully read data from NOR flash.\n", __FUNCTION__));
 
 ErrorExit:
 
@@ -878,7 +878,7 @@ NorFlashErase (
                );
     if (EFI_ERROR (Status)) {
       DEBUG ((
-        EFI_D_ERROR,
+        DEBUG_ERROR,
         "%a: Failed hybrid erase: %r\n",
         __FUNCTION__,
         Status
@@ -893,7 +893,7 @@ NorFlashErase (
   for (Block = Lba; Block < (Lba + NumLba); Block++) {
     Status = ConfigureNorFlashWriteEnLatch (Private, TRUE);
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "%a: Could not enable NOR flash WREN.\n", __FUNCTION__));
+      DEBUG ((DEBUG_ERROR, "%a: Could not enable NOR flash WREN.\n", __FUNCTION__));
       goto ErrorExit;
     }
 
@@ -914,24 +914,24 @@ NorFlashErase (
 
     Status = QSPIPERFORMTRANSACTION (&Packet);
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "%a: Could not erase data from NOR flash.\n", __FUNCTION__));
+      DEBUG ((DEBUG_ERROR, "%a: Could not erase data from NOR flash.\n", __FUNCTION__));
       goto ErrorExit;
     }
 
     Status = WaitNorFlashWriteComplete (Private);
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "%a: Could not complete NOR flash write.\n", __FUNCTION__));
+      DEBUG ((DEBUG_ERROR, "%a: Could not complete NOR flash write.\n", __FUNCTION__));
       goto ErrorExit;
     }
 
     Status = ConfigureNorFlashWriteEnLatch (Private, FALSE);
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "%a: Could not enable NOR flash WREN.\n", __FUNCTION__));
+      DEBUG ((DEBUG_ERROR, "%a: Could not enable NOR flash WREN.\n", __FUNCTION__));
       goto ErrorExit;
     }
   }
 
-  DEBUG ((EFI_D_INFO, "%a: Successfully erased data from NOR flash.\n", __FUNCTION__));
+  DEBUG ((DEBUG_INFO, "%a: Successfully erased data from NOR flash.\n", __FUNCTION__));
 
 ErrorExit:
 
@@ -1060,7 +1060,7 @@ NorFlashWriteSinglePage (
   ZeroMem (Private->CommandBuffer, CmdSize + Size);
   Status = ConfigureNorFlashWriteEnLatch (Private, TRUE);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "%a: Could not enable NOR flash WREN.\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Could not enable NOR flash WREN.\n", __FUNCTION__));
     goto ErrorExit;
   }
 
@@ -1081,23 +1081,23 @@ NorFlashWriteSinglePage (
 
   Status = QSPIPERFORMTRANSACTION (&Packet);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "%a: Could not write data to NOR flash.\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Could not write data to NOR flash.\n", __FUNCTION__));
     goto ErrorExit;
   }
 
   Status = WaitNorFlashWriteComplete (Private);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "%a: Could not complete NOR flash write.\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Could not complete NOR flash write.\n", __FUNCTION__));
     goto ErrorExit;
   }
 
   Status = ConfigureNorFlashWriteEnLatch (Private, FALSE);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "%a: Could not disable NOR flash WREN.\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Could not disable NOR flash WREN.\n", __FUNCTION__));
     goto ErrorExit;
   }
 
-  DEBUG ((EFI_D_INFO, "%a: Successfully wrote data to NOR flash.\n", __FUNCTION__));
+  DEBUG ((DEBUG_INFO, "%a: Successfully wrote data to NOR flash.\n", __FUNCTION__));
 
 ErrorExit:
 
@@ -1156,7 +1156,7 @@ NorFlashWrite (
 
     Status = NorFlashWriteSinglePage (This, Offset, BytesToWrite, Buffer);
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "%a: Could not write data to NOR flash.\n", __FUNCTION__));
+      DEBUG ((DEBUG_ERROR, "%a: Could not write data to NOR flash.\n", __FUNCTION__));
       return Status;
     }
 
@@ -1165,7 +1165,7 @@ NorFlashWrite (
     Size   -= BytesToWrite;
   }
 
-  DEBUG ((EFI_D_INFO, "%a: Successfully wrote data to NOR flash.\n", __FUNCTION__));
+  DEBUG ((DEBUG_INFO, "%a: Successfully wrote data to NOR flash.\n", __FUNCTION__));
 
   return Status;
 }
@@ -1380,7 +1380,7 @@ NorFlashInitialise (
   // Initialize QSPI controller
   Status = QspiInitialize ((EFI_PHYSICAL_ADDRESS)QspiBaseAddress);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "QSPI Initialization Failed.\n"));
+    DEBUG ((DEBUG_ERROR, "QSPI Initialization Failed.\n"));
     goto ErrorExit;
   }
 

--- a/Silicon/NVIDIA/Drivers/OemDescStatusCodeDxe/OemDescStatusCodeDxe.c
+++ b/Silicon/NVIDIA/Drivers/OemDescStatusCodeDxe/OemDescStatusCodeDxe.c
@@ -305,7 +305,7 @@ OemDescStatusCodeDxeDriverEntryPoint (
                   &mExitBootServicesEvent
                   );
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "%a: Failed to create exit boot services event\r\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Failed to create exit boot services event\r\n", __FUNCTION__));
     return Status;
   }
 

--- a/Silicon/NVIDIA/Drivers/PcieControllerDxe/PcieControllerDxe.c
+++ b/Silicon/NVIDIA/Drivers/PcieControllerDxe/PcieControllerDxe.c
@@ -327,7 +327,7 @@ ConfigureSidebandSignals (
                   );
   if (EFI_ERROR (Status) || (mPmux == NULL)) {
     DEBUG ((
-      EFI_D_ERROR,
+      DEBUG_ERROR,
       "%a: Couldn't get gNVIDIAPinMuxProtocolGuid Handle: %r\n",
       __FUNCTION__,
       Status
@@ -686,7 +686,7 @@ PrepareHost (
       val |= (0xF << PORT_LINK_CAP_SHIFT);
       break;
     default:
-      DEBUG ((EFI_D_ERROR, "Invalid num-lanes %u, Setting default to '1'\r\n", Private->NumLanes));
+      DEBUG ((DEBUG_ERROR, "Invalid num-lanes %u, Setting default to '1'\r\n", Private->NumLanes));
       val |= (0x1 << PORT_LINK_CAP_SHIFT);
   }
 
@@ -750,19 +750,19 @@ PrepareHost (
   /* Disable write permission to DBI_RO_WR_EN protected registers */
   MmioAnd32 (Private->DbiBase + PCIE_MISC_CONTROL_1_OFF, ~PCIE_DBI_RO_WR_EN);
 
-  DEBUG ((EFI_D_INFO, "Programming CORE registers is done\r\n"));
+  DEBUG ((DEBUG_INFO, "Programming CORE registers is done\r\n"));
 
   Count = sizeof (CoreClockNames)/sizeof (CoreClockNames[0]);
   for (Index = 0; Index < Count; Index++) {
     Status = DeviceDiscoverySetClockFreq (ControllerHandle, CoreClockNames[Index], 500000000);
     if (!EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_INFO, "Core clock is set\r\n"));
+      DEBUG ((DEBUG_INFO, "Core clock is set\r\n"));
       break;
     }
   }
 
   if (Index == Count) {
-    DEBUG ((EFI_D_ERROR, "Failed to set core_clk\r\n"));
+    DEBUG ((DEBUG_ERROR, "Failed to set core_clk\r\n"));
     return Status;
   }
 
@@ -802,14 +802,14 @@ CheckLinkUp (
   if (val & PCI_EXP_LNKCTL_STATUS_DLL_ACTIVE) {
     Private->LinkUp = TRUE;
     DEBUG ((
-      EFI_D_INFO,
+      DEBUG_INFO,
       "PCIe Controller-%d Link is UP (Speed: %d)\r\n",
       Private->CtrlId,
       (val & 0xf0000) >> 16
       ));
   } else {
     Private->LinkUp = FALSE;
-    DEBUG ((EFI_D_ERROR, "PCIe Controller-%d Link is DOWN\r\n", Private->CtrlId));
+    DEBUG ((DEBUG_ERROR, "PCIe Controller-%d Link is DOWN\r\n", Private->CtrlId));
   }
 
   return Private->LinkUp;
@@ -862,13 +862,13 @@ InitializeController (
   for (Index = 0; Index < Count; Index++) {
     Status = DeviceDiscoveryEnableClock (ControllerHandle, CoreClockNames[Index], 1);
     if (!EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_INFO, "Enabled Core clock\r\n"));
+      DEBUG ((DEBUG_INFO, "Enabled Core clock\r\n"));
       break;
     }
   }
 
   if (Index == Count) {
-    DEBUG ((EFI_D_ERROR, "Failed to enable core_clk\r\n"));
+    DEBUG ((DEBUG_ERROR, "Failed to enable core_clk\r\n"));
     return Status;
   }
 
@@ -877,20 +877,20 @@ InitializeController (
   for (Index = 0; Index < Count; Index++) {
     Status = DeviceDiscoveryConfigReset (ControllerHandle, CoreAPBResetNames[Index], 0);
     if (!EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_INFO, "De-asserted Core APB reset\r\n"));
+      DEBUG ((DEBUG_INFO, "De-asserted Core APB reset\r\n"));
       break;
     }
   }
 
   if (Index == Count) {
-    DEBUG ((EFI_D_ERROR, "Failed to de-assert Core APB reset\r\n"));
+    DEBUG ((DEBUG_ERROR, "Failed to de-assert Core APB reset\r\n"));
     return Status;
   }
 
   /* Configure P2U */
   Status = gBS->LocateProtocol (&gNVIDIATegraP2UProtocolGuid, NULL, (VOID **)&P2U);
   if (EFI_ERROR (Status) || (P2U == NULL)) {
-    DEBUG ((EFI_D_ERROR, "%a: Failed to get gNVIDIATegraP2UProtocolGuid Handle: %r\n", __FUNCTION__, Status));
+    DEBUG ((DEBUG_ERROR, "%a: Failed to get gNVIDIATegraP2UProtocolGuid Handle: %r\n", __FUNCTION__, Status));
     return EFI_UNSUPPORTED;
   }
 
@@ -901,7 +901,7 @@ InitializeController (
                &PropertySize
                );
   if (Property == NULL) {
-    DEBUG ((EFI_D_ERROR, "%a: Failed to get P2U PHY entries\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Failed to get P2U PHY entries\n", __FUNCTION__));
     return EFI_UNSUPPORTED;
   }
 
@@ -912,7 +912,7 @@ InitializeController (
     P2UId = SwapBytes32 (P2UId);
 
     if (EFI_ERROR (P2U->Init (P2U, P2UId))) {
-      DEBUG ((EFI_D_ERROR, "Failed to Initialize P2U\n"));
+      DEBUG ((DEBUG_ERROR, "Failed to Initialize P2U\n"));
     }
   }
 
@@ -1004,7 +1004,7 @@ InitializeController (
   val |= APPL_INTR_EN_L1_8_INTX_EN;
   MmioWrite32 (Private->ApplSpace + APPL_INTR_EN_L1_8_0, val);
 
-  DEBUG ((EFI_D_INFO, "Programming APPL registers is done\r\n"));
+  DEBUG ((DEBUG_INFO, "Programming APPL registers is done\r\n"));
 
   /* De-assert reset to CORE */
   Count = sizeof (CoreResetNames)/sizeof (CoreResetNames[0]);
@@ -1015,13 +1015,13 @@ InitializeController (
                0
                );
     if (!EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_INFO, "De-asserted Core reset\r\n"));
+      DEBUG ((DEBUG_INFO, "De-asserted Core reset\r\n"));
       break;
     }
   }
 
   if (Index == Count) {
-    DEBUG ((EFI_D_ERROR, "Failed to De-assert Core reset\r\n"));
+    DEBUG ((DEBUG_ERROR, "Failed to De-assert Core reset\r\n"));
     return Status;
   }
 
@@ -1040,7 +1040,7 @@ InitializeController (
 
   Status = PrepareHost (Private, ControllerHandle, DeviceTreeNode);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "Unable to Prepare Host controller (%r)\r\n", Status));
+    DEBUG ((DEBUG_ERROR, "Unable to Prepare Host controller (%r)\r\n", Status));
     return Status;
   }
 
@@ -1066,8 +1066,8 @@ InitializeController (
       goto exit;
     }
 
-    DEBUG ((EFI_D_INFO, "Link is down in DLL"));
-    DEBUG ((EFI_D_INFO, "Trying again with DLFE disabled\n"));
+    DEBUG ((DEBUG_INFO, "Link is down in DLL"));
+    DEBUG ((DEBUG_INFO, "Trying again with DLFE disabled\n"));
 
     /* Disable LTSSM */
     val  = MmioRead32 (Private->ApplSpace + APPL_CTRL);
@@ -1083,13 +1083,13 @@ InitializeController (
                  1
                  );
       if (!EFI_ERROR (Status)) {
-        DEBUG ((EFI_D_INFO, "Asserted Core reset\r\n"));
+        DEBUG ((DEBUG_INFO, "Asserted Core reset\r\n"));
         break;
       }
     }
 
     if (Index == Count) {
-      DEBUG ((EFI_D_ERROR, "Failed to Assert Core reset\r\n"));
+      DEBUG ((DEBUG_ERROR, "Failed to Assert Core reset\r\n"));
       return Status;
     }
 
@@ -1102,13 +1102,13 @@ InitializeController (
                  0
                  );
       if (!EFI_ERROR (Status)) {
-        DEBUG ((EFI_D_INFO, "De-asserted Core reset\r\n"));
+        DEBUG ((DEBUG_INFO, "De-asserted Core reset\r\n"));
         break;
       }
     }
 
     if (Index == Count) {
-      DEBUG ((EFI_D_ERROR, "Failed to De-assert Core reset\r\n"));
+      DEBUG ((DEBUG_ERROR, "Failed to De-assert Core reset\r\n"));
       return Status;
     }
 
@@ -1119,7 +1119,7 @@ InitializeController (
 
     Status = PrepareHost (Private, ControllerHandle, DeviceTreeNode);
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "Unable to Prepare Host controller (%r)\r\n", Status));
+      DEBUG ((DEBUG_ERROR, "Unable to Prepare Host controller (%r)\r\n", Status));
       return Status;
     }
 
@@ -1199,7 +1199,7 @@ TegraPciePMETurnOff (
 
   if (!Private->LinkUp) {
     DEBUG ((
-      EFI_D_INFO,
+      DEBUG_INFO,
       "PCIe Controller-%d Link is not UP\r\n",
       Private->CtrlId
       ));
@@ -1212,7 +1212,7 @@ TegraPciePMETurnOff (
   }
 
   if (TegraPcieTryLinkL2 (Private)) {
-    DEBUG ((EFI_D_ERROR, "Link didn't transition to L2 state\r\n"));
+    DEBUG ((DEBUG_ERROR, "Link didn't transition to L2 state\r\n"));
 
     /*
      * TX lane clock freq will reset to Gen1 only if link is in L2
@@ -1234,7 +1234,7 @@ TegraPciePMETurnOff (
           ((data & APPL_DEBUG_LTSSM_STATE_MASK) == LTSSM_STATE_DETECT_WAIT))
         )
     {
-      DEBUG ((EFI_D_ERROR, "Link didn't go to detect state as well\r\n"));
+      DEBUG ((DEBUG_ERROR, "Link didn't go to detect state as well\r\n"));
     }
 
     data  = MmioRead32 (Private->ApplSpace + APPL_CTRL);
@@ -1277,13 +1277,13 @@ UninitializeController (
                1
                );
     if (!EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_INFO, "Asserted Core reset\r\n"));
+      DEBUG ((DEBUG_INFO, "Asserted Core reset\r\n"));
       break;
     }
   }
 
   if (Index == Count) {
-    DEBUG ((EFI_D_ERROR, "Failed to assert Core reset\r\n"));
+    DEBUG ((DEBUG_ERROR, "Failed to assert Core reset\r\n"));
     return Status;
   }
 
@@ -1296,13 +1296,13 @@ UninitializeController (
                1
                );
     if (!EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_INFO, "Asserted Core APB reset\r\n"));
+      DEBUG ((DEBUG_INFO, "Asserted Core APB reset\r\n"));
       break;
     }
   }
 
   if (Index == Count) {
-    DEBUG ((EFI_D_ERROR, "Failed to assert Core APB reset\r\n"));
+    DEBUG ((DEBUG_ERROR, "Failed to assert Core APB reset\r\n"));
     return Status;
   }
 
@@ -1315,13 +1315,13 @@ UninitializeController (
                0
                );
     if (!EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_INFO, "Disabled Core clock\r\n"));
+      DEBUG ((DEBUG_INFO, "Disabled Core clock\r\n"));
       break;
     }
   }
 
   if (Index == Count) {
-    DEBUG ((EFI_D_ERROR, "Failed to Disable core_clk\r\n"));
+    DEBUG ((DEBUG_ERROR, "Failed to Disable core_clk\r\n"));
     return Status;
   }
 
@@ -1329,11 +1329,11 @@ UninitializeController (
     if (PcdGetBool (PcdBPMPPCIeControllerEnable)) {
       Status = BpmpProcessSetCtrlState (Private->BpmpIpcProtocol, Private->CtrlId, 0);
       if (EFI_ERROR (Status)) {
-        DEBUG ((EFI_D_ERROR, "Failed to disable Controller-%u\n", Private->CtrlId));
+        DEBUG ((DEBUG_ERROR, "Failed to disable Controller-%u\n", Private->CtrlId));
         return Status;
       }
 
-      DEBUG ((EFI_D_INFO, "Disabled Controller-%u through BPMP-FW\n", Private->CtrlId));
+      DEBUG ((DEBUG_INFO, "Disabled Controller-%u through BPMP-FW\n", Private->CtrlId));
     }
   }
 
@@ -1635,7 +1635,7 @@ DeviceDiscoveryNotify (
         Private->PcieRootBridgeConfigurationIo.SegmentNumber = SwapBytes32 (Private->PcieRootBridgeConfigurationIo.SegmentNumber);
       }
 
-      DEBUG ((EFI_D_INFO, "Segment Number = %u\n", Private->PcieRootBridgeConfigurationIo.SegmentNumber));
+      DEBUG ((DEBUG_INFO, "Segment Number = %u\n", Private->PcieRootBridgeConfigurationIo.SegmentNumber));
 
       Private->CtrlId = Private->PcieRootBridgeConfigurationIo.SegmentNumber;
 
@@ -1652,7 +1652,7 @@ DeviceDiscoveryNotify (
         Private->CtrlId = SwapBytes32 (Private->CtrlId);
       }
 
-      DEBUG ((EFI_D_INFO, "Controller-ID = %u\n", Private->CtrlId));
+      DEBUG ((DEBUG_INFO, "Controller-ID = %u\n", Private->CtrlId));
 
       Property = fdt_getprop (
                    DeviceTreeNode->DeviceTreeBase,
@@ -1680,7 +1680,7 @@ DeviceDiscoveryNotify (
         Private->MaxLinkSpeed = 4;
       }
 
-      DEBUG ((EFI_D_INFO, "Max Link Speed = %u\n", Private->MaxLinkSpeed));
+      DEBUG ((DEBUG_INFO, "Max Link Speed = %u\n", Private->MaxLinkSpeed));
 
       Private->EnableGicV2m = ParseGicMsiBase (DeviceTreeNode, &Private->GicBase, &Private->MsiBase);
       if (Private->EnableGicV2m) {
@@ -1704,7 +1704,7 @@ DeviceDiscoveryNotify (
         Private->NumLanes = 1;
       }
 
-      DEBUG ((EFI_D_INFO, "Number of lanes = %u\n", Private->NumLanes));
+      DEBUG ((DEBUG_INFO, "Number of lanes = %u\n", Private->NumLanes));
 
       if (NULL != fdt_get_property (
                     DeviceTreeNode->DeviceTreeBase,
@@ -1721,7 +1721,7 @@ DeviceDiscoveryNotify (
       /* Enable slot supplies */
       Status = gBS->LocateProtocol (&gNVIDIARegulatorProtocolGuid, NULL, (VOID **)&Regulator);
       if (EFI_ERROR (Status) || (Regulator == NULL)) {
-        DEBUG ((EFI_D_ERROR, "%a: Couldn't get gNVIDIARegulatorProtocolGuid Handle: %r\n", __FUNCTION__, Status));
+        DEBUG ((DEBUG_ERROR, "%a: Couldn't get gNVIDIARegulatorProtocolGuid Handle: %r\n", __FUNCTION__, Status));
         Status = EFI_UNSUPPORTED;
         goto ErrorExit;
       }
@@ -1737,10 +1737,10 @@ DeviceDiscoveryNotify (
         Val = SwapBytes32 (*(UINT32 *)Property);
         /* Enable the vddio-pex-ctl supply */
         if (EFI_ERROR (Regulator->Enable (Regulator, Val, TRUE))) {
-          DEBUG ((EFI_D_ERROR, "Failed to Enable vddio-pex-ctl supply regulator\n"));
+          DEBUG ((DEBUG_ERROR, "Failed to Enable vddio-pex-ctl supply regulator\n"));
         }
       } else {
-        DEBUG ((EFI_D_INFO, "Failed to find vddio-pex-ctl supply regulator\n"));
+        DEBUG ((DEBUG_INFO, "Failed to find vddio-pex-ctl supply regulator\n"));
       }
 
       /* Get the 3v3 supply */
@@ -1754,10 +1754,10 @@ DeviceDiscoveryNotify (
         Val = SwapBytes32 (*(UINT32 *)Property);
         /* Enable the 3v3 supply */
         if (EFI_ERROR (Regulator->Enable (Regulator, Val, TRUE))) {
-          DEBUG ((EFI_D_ERROR, "Failed to Enable 3v3 Regulator\n"));
+          DEBUG ((DEBUG_ERROR, "Failed to Enable 3v3 Regulator\n"));
         }
       } else {
-        DEBUG ((EFI_D_INFO, "Failed to find 3v3 slot supply regulator\n"));
+        DEBUG ((DEBUG_INFO, "Failed to find 3v3 slot supply regulator\n"));
       }
 
       /* Get the 12v supply */
@@ -1771,10 +1771,10 @@ DeviceDiscoveryNotify (
         Val = SwapBytes32 (*(UINT32 *)Property);
         /* Enable the 12v supply */
         if (EFI_ERROR (Regulator->Enable (Regulator, Val, TRUE))) {
-          DEBUG ((EFI_D_ERROR, "Failed to Enable 12v Regulator\n"));
+          DEBUG ((DEBUG_ERROR, "Failed to Enable 12v Regulator\n"));
         }
       } else {
-        DEBUG ((EFI_D_INFO, "Failed to find 12v slot supply regulator\n"));
+        DEBUG ((DEBUG_INFO, "Failed to find 12v slot supply regulator\n"));
       }
 
       /* Spec defined T_PVPERL delay (100ms) after enabling power to the slot */
@@ -1787,7 +1787,7 @@ DeviceDiscoveryNotify (
 
         Status = gBS->LocateProtocol (&gNVIDIABpmpIpcProtocolGuid, NULL, (VOID **)&Private->BpmpIpcProtocol);
         if (EFI_ERROR (Status)) {
-          DEBUG ((EFI_D_ERROR, "Failed to get BPMP-FW handle\n"));
+          DEBUG ((DEBUG_ERROR, "Failed to get BPMP-FW handle\n"));
           Status = EFI_NOT_READY;
           goto ErrorExit;
         }
@@ -1795,12 +1795,12 @@ DeviceDiscoveryNotify (
         if (PcdGetBool (PcdBPMPPCIeControllerEnable)) {
           Status = BpmpProcessSetCtrlState (Private->BpmpIpcProtocol, Private->CtrlId, 1);
           if (EFI_ERROR (Status)) {
-            DEBUG ((EFI_D_ERROR, "Failed to Enable Controller-%u\n", Private->CtrlId));
+            DEBUG ((DEBUG_ERROR, "Failed to Enable Controller-%u\n", Private->CtrlId));
             Status = EFI_NOT_READY;
             goto ErrorExit;
           }
 
-          DEBUG ((EFI_D_INFO, "Enabled Controller-%u through BPMP-FW\n", Private->CtrlId));
+          DEBUG ((DEBUG_INFO, "Enabled Controller-%u through BPMP-FW\n", Private->CtrlId));
         }
       }
 
@@ -1832,7 +1832,7 @@ DeviceDiscoveryNotify (
 
       Status = InitializeController (Private, ControllerHandle, DeviceTreeNode);
       if (EFI_ERROR (Status)) {
-        DEBUG ((EFI_D_ERROR, "%a: Unable to initialize controller (%r)\r\n", __FUNCTION__, Status));
+        DEBUG ((DEBUG_ERROR, "%a: Unable to initialize controller (%r)\r\n", __FUNCTION__, Status));
         goto ErrorExit;
       }
 
@@ -1845,7 +1845,7 @@ DeviceDiscoveryNotify (
                       &ExitBootServiceEvent
                       );
       if (EFI_ERROR (Status)) {
-        DEBUG ((EFI_D_ERROR, "%a: Unable to setup exit boot services uninitialize. (%r)\r\n", __FUNCTION__, Status));
+        DEBUG ((DEBUG_ERROR, "%a: Unable to setup exit boot services uninitialize. (%r)\r\n", __FUNCTION__, Status));
         goto ErrorExit;
       }
 
@@ -1864,7 +1864,7 @@ DeviceDiscoveryNotify (
                       &PropertySize
                       );
       if ((BusProperty == NULL) || (PropertySize != 2 * sizeof (UINT32))) {
-        DEBUG ((EFI_D_INFO, "PCIe Controller: unknown bus size in fdt, default to 0-255\r\n"));
+        DEBUG ((DEBUG_INFO, "PCIe Controller: unknown bus size in fdt, default to 0-255\r\n"));
         RootBridge->Bus.Base  = 0x0;
         RootBridge->Bus.Limit = 0xff;
       } else {
@@ -1883,7 +1883,7 @@ DeviceDiscoveryNotify (
       RangeSize       = (AddressCells + PciAddressCells + SizeCells) * sizeof (UINT32);
 
       if (PciAddressCells != 3) {
-        DEBUG ((EFI_D_ERROR, "PCIe Controller, size 3 is required for address-cells, got %d\r\n", PciAddressCells));
+        DEBUG ((DEBUG_ERROR, "PCIe Controller, size 3 is required for address-cells, got %d\r\n", PciAddressCells));
         Status = EFI_DEVICE_ERROR;
         goto ErrorExit;
       }
@@ -1902,7 +1902,7 @@ DeviceDiscoveryNotify (
       RootBridge->PMemAbove4G.Base = MAX_UINT64;
 
       if ((RangesProperty == NULL) || ((PropertySize % RangeSize) != 0)) {
-        DEBUG ((EFI_D_ERROR, "PCIe Controller: Unsupported ranges configuration\r\n"));
+        DEBUG ((DEBUG_ERROR, "PCIe Controller: Unsupported ranges configuration\r\n"));
         Status = EFI_UNSUPPORTED;
         goto ErrorExit;
       }
@@ -1932,7 +1932,7 @@ DeviceDiscoveryNotify (
           CopyMem (&HostAddress, RangesProperty + (PciAddressCells * sizeof (UINT32)), sizeof (UINT32));
           HostAddress = SwapBytes32 (HostAddress);
         } else {
-          DEBUG ((EFI_D_ERROR, "PCIe Controller: Invalid address cells (%d)\r\n", AddressCells));
+          DEBUG ((DEBUG_ERROR, "PCIe Controller: Invalid address cells (%d)\r\n", AddressCells));
           Status = EFI_DEVICE_ERROR;
           break;
         }
@@ -1944,7 +1944,7 @@ DeviceDiscoveryNotify (
           CopyMem (&Size, RangesProperty + ((PciAddressCells + AddressCells) * sizeof (UINT32)), sizeof (UINT32));
           Size = SwapBytes32 (Size);
         } else {
-          DEBUG ((EFI_D_ERROR, "PCIe Controller: Invalid size cells (%d)\r\n", SizeCells));
+          DEBUG ((DEBUG_ERROR, "PCIe Controller: Invalid size cells (%d)\r\n", SizeCells));
           Status = EFI_DEVICE_ERROR;
           goto ErrorExit;
         }
@@ -2002,7 +2002,7 @@ DeviceDiscoveryNotify (
             );
           Private->AddressMapInfo[Private->AddressMapCount].SpaceCode = 3;
         } else {
-          DEBUG ((EFI_D_ERROR, "PCIe Controller: Unknown region 0x%08x 0x%016llx-0x%016llx T 0x%016llx\r\n", Flags, DeviceAddress, Limit, Translation));
+          DEBUG ((DEBUG_ERROR, "PCIe Controller: Unknown region 0x%08x 0x%016llx-0x%016llx T 0x%016llx\r\n", Flags, DeviceAddress, Limit, Translation));
           ASSERT (FALSE);
           Status = EFI_DEVICE_ERROR;
           goto ErrorExit;

--- a/Silicon/NVIDIA/Drivers/PinMuxDxe/PinMuxDxe.c
+++ b/Silicon/NVIDIA/Drivers/PinMuxDxe/PinMuxDxe.c
@@ -151,7 +151,7 @@ DeviceDiscoveryNotify (
                  );
       if (EFI_ERROR (Status)) {
         DEBUG ((
-          EFI_D_ERROR,
+          DEBUG_ERROR,
           "%a: Couldn't find PinMux address range\n",
           __FUNCTION__
           ));
@@ -160,7 +160,7 @@ DeviceDiscoveryNotify (
 
       Private = AllocatePool (sizeof (PINMUX_DXE_PRIVATE));
       if (NULL == Private) {
-        DEBUG ((EFI_D_ERROR, "%a: Failed to allocate Memory\r\n", __FUNCTION__));
+        DEBUG ((DEBUG_ERROR, "%a: Failed to allocate Memory\r\n", __FUNCTION__));
         Status = EFI_OUT_OF_RESOURCES;
         return Status;
       }

--- a/Silicon/NVIDIA/Drivers/QspiControllerDxe/QspiControllerDxe.c
+++ b/Silicon/NVIDIA/Drivers/QspiControllerDxe/QspiControllerDxe.c
@@ -439,7 +439,7 @@ DeviceDiscoveryNotify (
 
       Status = QspiInitialize (Private->QspiBaseAddress);
       if (EFI_ERROR (Status)) {
-        DEBUG ((EFI_D_ERROR, "QSPI Initialization Failed.\n"));
+        DEBUG ((DEBUG_ERROR, "QSPI Initialization Failed.\n"));
         goto ErrorExit;
       }
 
@@ -458,7 +458,7 @@ DeviceDiscoveryNotify (
                       &Private->VirtualAddrChangeEvent
                       );
       if (EFI_ERROR (Status)) {
-        DEBUG ((EFI_D_ERROR, "Failed to create virtual address event\r\n"));
+        DEBUG ((DEBUG_ERROR, "Failed to create virtual address event\r\n"));
         goto ErrorExit;
       }
 

--- a/Silicon/NVIDIA/Drivers/RamDiskOS/RamDiskOS.c
+++ b/Silicon/NVIDIA/Drivers/RamDiskOS/RamDiskOS.c
@@ -52,7 +52,7 @@ RamDiskOSEntryPoint (
 
   Status = gBS->LocateProtocol (&gEfiRamDiskProtocolGuid, NULL, (VOID **)&RamDisk);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "%a: Couldn't find the RAM Disk protocol - %r\n", __FUNCTION__, Status));
+    DEBUG ((DEBUG_ERROR, "%a: Couldn't find the RAM Disk protocol - %r\n", __FUNCTION__, Status));
     return Status;
   }
 
@@ -65,7 +65,7 @@ RamDiskOSEntryPoint (
                           &DevicePath
                           );
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "%a: Failed to register RAM Disk - %r\n", __FUNCTION__, Status));
+    DEBUG ((DEBUG_ERROR, "%a: Failed to register RAM Disk - %r\n", __FUNCTION__, Status));
   }
 
   return Status;

--- a/Silicon/NVIDIA/Drivers/RegulatorDxe/RegulatorDxe.c
+++ b/Silicon/NVIDIA/Drivers/RegulatorDxe/RegulatorDxe.c
@@ -209,7 +209,7 @@ ReadPmicRegister (
                                                             (EFI_I2C_REQUEST_PACKET *)&Operation,
                                                             NULL
                                                             );
-    DEBUG ((EFI_D_VERBOSE, "%a: 0x%02x <- 0x%02x, %r\r\n", __FUNCTION__, *Value, Address, Status));
+    DEBUG ((DEBUG_VERBOSE, "%a: 0x%02x <- 0x%02x, %r\r\n", __FUNCTION__, *Value, Address, Status));
   } else {
     Operation.OperationCount             = 2;
     Operation.Operation[0].Flags         = 0;
@@ -225,7 +225,7 @@ ReadPmicRegister (
                                                             (EFI_I2C_REQUEST_PACKET *)&Operation,
                                                             NULL
                                                             );
-    DEBUG ((EFI_D_VERBOSE, "%a: 0x%02x <- 0x%02x, %r\r\n", __FUNCTION__, *Value, Address, Status));
+    DEBUG ((DEBUG_VERBOSE, "%a: 0x%02x <- 0x%02x, %r\r\n", __FUNCTION__, *Value, Address, Status));
   }
 
   return Status;
@@ -270,7 +270,7 @@ WritePmicRegister (
                                                           &Operation,
                                                           NULL
                                                           );
-  DEBUG ((EFI_D_VERBOSE, "%a: 0x%02x -> 0x%02x, %r\r\n", __FUNCTION__, Value, Address, Status));
+  DEBUG ((DEBUG_VERBOSE, "%a: 0x%02x -> 0x%02x, %r\r\n", __FUNCTION__, Value, Address, Status));
   return Status;
 }
 
@@ -337,7 +337,7 @@ RegulatorGetInfo (
       UINT8  Data;
       Status = ReadPmicRegister (Entry->I2cIoProtocol, Entry->PmicSetting->ConfigRegister, &Data, Entry->I2cDeviceGuid);
       if (EFI_ERROR (Status)) {
-        DEBUG ((EFI_D_ERROR, "%a, Failed to read configuration register: %r\r\n", __FUNCTION__, Status));
+        DEBUG ((DEBUG_ERROR, "%a, Failed to read configuration register: %r\r\n", __FUNCTION__, Status));
         return Status;
       }
 
@@ -350,7 +350,7 @@ RegulatorGetInfo (
       if (Entry->MicrovoltStep != 0x00) {
         Status = ReadPmicRegister (Entry->I2cIoProtocol, Entry->PmicSetting->VoltageRegister, &Data, Entry->I2cDeviceGuid);
         if (EFI_ERROR (Status)) {
-          DEBUG ((EFI_D_ERROR, "%a, Failed to read voltage register: %r\r\n", __FUNCTION__, Status));
+          DEBUG ((DEBUG_ERROR, "%a, Failed to read voltage register: %r\r\n", __FUNCTION__, Status));
           return Status;
         }
 
@@ -585,7 +585,7 @@ RegulatorEnable (
                                       GpioMode
                                       );
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "%a, Failed to set gpio 0x%x mode: %r\r\n", __FUNCTION__, Entry->Gpio, Status));
+      DEBUG ((DEBUG_ERROR, "%a, Failed to set gpio 0x%x mode: %r\r\n", __FUNCTION__, Entry->Gpio, Status));
       return EFI_DEVICE_ERROR;
     }
 
@@ -596,7 +596,7 @@ RegulatorEnable (
     UINT8  DataNew;
     Status = ReadPmicRegister (Entry->I2cIoProtocol, Entry->PmicSetting->ConfigRegister, &DataOriginal, Entry->I2cDeviceGuid);
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "%a, Failed to read configuration register: %r\r\n", __FUNCTION__, Status));
+      DEBUG ((DEBUG_ERROR, "%a, Failed to read configuration register: %r\r\n", __FUNCTION__, Status));
       return Status;
     }
 
@@ -611,7 +611,7 @@ RegulatorEnable (
     if (DataNew != DataOriginal) {
       Status = WritePmicRegister (Entry->I2cIoProtocol, Entry->PmicSetting->ConfigRegister, DataNew, Entry->I2cDeviceGuid);
       if (EFI_ERROR (Status)) {
-        DEBUG ((EFI_D_ERROR, "%a, Failed to write configuration register: %r\r\n", __FUNCTION__, Status));
+        DEBUG ((DEBUG_ERROR, "%a, Failed to write configuration register: %r\r\n", __FUNCTION__, Status));
         return Status;
       }
 
@@ -681,7 +681,7 @@ RegulatorSetVoltage (
       UINT8  DataNew;
       Status = ReadPmicRegister (Entry->I2cIoProtocol, Entry->PmicSetting->VoltageRegister, &DataOriginal, Entry->I2cDeviceGuid);
       if (EFI_ERROR (Status)) {
-        DEBUG ((EFI_D_ERROR, "%a, Failed to read voltage register: %r\r\n", __FUNCTION__, Status));
+        DEBUG ((DEBUG_ERROR, "%a, Failed to read voltage register: %r\r\n", __FUNCTION__, Status));
         return Status;
       }
 
@@ -693,7 +693,7 @@ RegulatorSetVoltage (
       if (DataNew != DataOriginal) {
         Status = WritePmicRegister (Entry->I2cIoProtocol, Entry->PmicSetting->VoltageRegister, DataNew, Entry->I2cDeviceGuid);
         if (EFI_ERROR (Status)) {
-          DEBUG ((EFI_D_ERROR, "%a, Failed to write voltage register: %r\r\n", __FUNCTION__, Status));
+          DEBUG ((DEBUG_ERROR, "%a, Failed to write voltage register: %r\r\n", __FUNCTION__, Status));
           return Status;
         }
 
@@ -797,7 +797,7 @@ I2cIoProtocolReady (
     }
   }
 
-  DEBUG ((EFI_D_VERBOSE, "%a: Ready!!!\r\n", __FUNCTION__));
+  DEBUG ((DEBUG_VERBOSE, "%a: Ready!!!\r\n", __FUNCTION__));
   ListNode = GetFirstNode (&Private->RegulatorList);
   while (ListNode != &Private->RegulatorList) {
     REGULATOR_LIST_ENTRY  *Entry;
@@ -863,7 +863,7 @@ GpioProtocolReady (
 
   gBS->CloseEvent (Event);
 
-  DEBUG ((EFI_D_VERBOSE, "%a: Ready!!!\r\n", __FUNCTION__));
+  DEBUG ((DEBUG_VERBOSE, "%a: Ready!!!\r\n", __FUNCTION__));
   ListNode = GetFirstNode (&Private->RegulatorList);
   while (ListNode != &Private->RegulatorList) {
     REGULATOR_LIST_ENTRY  *Entry;
@@ -941,7 +941,7 @@ AddFixedRegulators (
 
     ListEntry = AllocateZeroPool (sizeof (REGULATOR_LIST_ENTRY));
     if (NULL == ListEntry) {
-      DEBUG ((EFI_D_ERROR, "%a: Failed to allocate list entry\r\n", __FUNCTION__));
+      DEBUG ((DEBUG_ERROR, "%a: Failed to allocate list entry\r\n", __FUNCTION__));
       return EFI_OUT_OF_RESOURCES;
     }
 
@@ -1104,7 +1104,7 @@ AddPmicRegulators (
           for (RegulatorIndex = 0; RegulatorIndex < PmicSupported[PmicIndex].SettingsSize; RegulatorIndex++) {
             ListEntry = AllocateZeroPool (sizeof (REGULATOR_LIST_ENTRY));
             if (NULL == ListEntry) {
-              DEBUG ((EFI_D_ERROR, "%a: Failed to allocate list entry\r\n", __FUNCTION__));
+              DEBUG ((DEBUG_ERROR, "%a: Failed to allocate list entry\r\n", __FUNCTION__));
               return EFI_OUT_OF_RESOURCES;
             }
 
@@ -1112,7 +1112,7 @@ AddPmicRegulators (
             ListEntry->Name        = fdt_get_name (Private->DeviceTreeBase, NodeOffset, NULL);
             Status                 = SetupPmicInfo (Private, ListEntry, PmicSupported[PmicIndex].RegulatorSettings[RegulatorIndex].Name, &PmicSupported[PmicIndex]);
             if (EFI_ERROR (Status)) {
-              DEBUG ((EFI_D_ERROR, "%a: Failed to get pmic info: %x, %r\r\n", __FUNCTION__, ListEntry->RegulatorId, Status));
+              DEBUG ((DEBUG_ERROR, "%a: Failed to get pmic info: %x, %r\r\n", __FUNCTION__, ListEntry->RegulatorId, Status));
               FreePool (ListEntry);
             } else {
               InsertTailList (&Private->RegulatorList, &ListEntry->Link);
@@ -1126,7 +1126,7 @@ AddPmicRegulators (
 
             ListEntry = AllocateZeroPool (sizeof (REGULATOR_LIST_ENTRY));
             if (NULL == ListEntry) {
-              DEBUG ((EFI_D_ERROR, "%a: Failed to allocate list entry\r\n", __FUNCTION__));
+              DEBUG ((DEBUG_ERROR, "%a: Failed to allocate list entry\r\n", __FUNCTION__));
               return EFI_OUT_OF_RESOURCES;
             }
 
@@ -1150,7 +1150,7 @@ AddPmicRegulators (
             ListEntry->Name          = (CONST CHAR8 *)fdt_getprop (Private->DeviceTreeBase, SubNodeOffset, "regulator-name", NULL);
             Status                   = SetupPmicInfo (Private, ListEntry, fdt_get_name (Private->DeviceTreeBase, SubNodeOffset, NULL), &PmicSupported[PmicIndex]);
             if (EFI_ERROR (Status)) {
-              DEBUG ((EFI_D_ERROR, "%a: Failed to get pmic info: %x, %r\r\n", __FUNCTION__, ListEntry->RegulatorId, Status));
+              DEBUG ((DEBUG_ERROR, "%a: Failed to get pmic info: %x, %r\r\n", __FUNCTION__, ListEntry->RegulatorId, Status));
               FreePool (ListEntry);
             } else {
               InsertTailList (&Private->RegulatorList, &ListEntry->Link);
@@ -1191,19 +1191,19 @@ BuildRegulatorNodes (
 
   Status = DtPlatformLoadDtb (&Private->DeviceTreeBase, &Private->DeviceTreeSize);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "%a failed to get device tree: %r\r\n", __FUNCTION__, Status));
+    DEBUG ((DEBUG_ERROR, "%a failed to get device tree: %r\r\n", __FUNCTION__, Status));
     goto ErrorExit;
   }
 
   Status = AddFixedRegulators (Private);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "%a failed to add fixed regulators: %r\r\n", __FUNCTION__, Status));
+    DEBUG ((DEBUG_ERROR, "%a failed to add fixed regulators: %r\r\n", __FUNCTION__, Status));
     goto ErrorExit;
   }
 
   Status = AddPmicRegulators (Private);
   if (EFI_ERROR ((Status))) {
-    DEBUG ((EFI_D_ERROR, "%a failed to add pmic regulators: %r\r\n", __FUNCTION__, Status));
+    DEBUG ((DEBUG_ERROR, "%a failed to add pmic regulators: %r\r\n", __FUNCTION__, Status));
     goto ErrorExit;
   }
 
@@ -1214,7 +1214,7 @@ BuildRegulatorNodes (
     if (NULL != Entry) {
       if (Entry->PmicSetting != NULL) {
         DEBUG ((
-          EFI_D_VERBOSE,
+          DEBUG_VERBOSE,
           "%a: Node 0x%04x, Name %a, PMIC Name %a, AlwaysEnabled %u, Available %u, Min %u, Max %u, Step, %u\r\n",
           __FUNCTION__,
           Entry->RegulatorId,
@@ -1228,7 +1228,7 @@ BuildRegulatorNodes (
           ));
       } else if (Entry->Gpio != 0) {
         DEBUG ((
-          EFI_D_VERBOSE,
+          DEBUG_VERBOSE,
           "%a: Node 0x%04x, Name %a, Gpio 0x%08x, AlwaysEnabled %u, Available %u, Min %u, Max %u, Step, %u\r\n",
           __FUNCTION__,
           Entry->RegulatorId,
@@ -1242,7 +1242,7 @@ BuildRegulatorNodes (
           ));
       } else {
         DEBUG ((
-          EFI_D_VERBOSE,
+          DEBUG_VERBOSE,
           "%a: Node 0x%04x, Name %a, AlwaysEnabled %u, Available %u, Min %u, Max %u, Step, %u\r\n",
           __FUNCTION__,
           Entry->RegulatorId,
@@ -1301,7 +1301,7 @@ RegulatorDxeInitialize (
 
   Private = AllocatePool (sizeof (REGULATOR_DXE_PRIVATE));
   if (NULL == Private) {
-    DEBUG ((EFI_D_ERROR, "%a: Failed to allocate private data stucture: %r\r\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Failed to allocate private data stucture: %r\r\n", __FUNCTION__));
     return EFI_OUT_OF_RESOURCES;
   }
 
@@ -1319,7 +1319,7 @@ RegulatorDxeInitialize (
 
   Status = BuildRegulatorNodes (Private);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "%a: Failed to parse regulator data: %r\r\n", __FUNCTION__, Status));
+    DEBUG ((DEBUG_ERROR, "%a: Failed to parse regulator data: %r\r\n", __FUNCTION__, Status));
     goto ErrorExit;
   }
 
@@ -1331,7 +1331,7 @@ RegulatorDxeInitialize (
                      &Private->GpioSearchToken
                      );
   if (NULL == GpioReadyEvent) {
-    DEBUG ((EFI_D_ERROR, "%a, Failed to create gpio notification event\r\n", __FUNCTION__, Status));
+    DEBUG ((DEBUG_ERROR, "%a, Failed to create gpio notification event\r\n", __FUNCTION__, Status));
     Status = EFI_OUT_OF_RESOURCES;
     goto ErrorExit;
   }
@@ -1344,7 +1344,7 @@ RegulatorDxeInitialize (
                       &Private->I2cIoSearchToken
                       );
   if (NULL == I2cIoReadyEvent) {
-    DEBUG ((EFI_D_ERROR, "%a, Failed to create I2cIo notification event\r\n", __FUNCTION__, Status));
+    DEBUG ((DEBUG_ERROR, "%a, Failed to create I2cIo notification event\r\n", __FUNCTION__, Status));
     Status = EFI_OUT_OF_RESOURCES;
     goto ErrorExit;
   }
@@ -1356,7 +1356,7 @@ RegulatorDxeInitialize (
                   NULL
                   );
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "%a, Failed to install protocols: %r\r\n", __FUNCTION__, Status));
+    DEBUG ((DEBUG_ERROR, "%a, Failed to install protocols: %r\r\n", __FUNCTION__, Status));
     goto ErrorExit;
   }
 

--- a/Silicon/NVIDIA/Drivers/SdMmcControllerDxe/SdMmcControllerDxe.c
+++ b/Silicon/NVIDIA/Drivers/SdMmcControllerDxe/SdMmcControllerDxe.c
@@ -220,7 +220,7 @@ DeviceDiscoveryNotify (
     case DeviceDiscoveryDriverBindingStart:
       Status = gBS->LocateProtocol (&gEfiPlatformToDriverConfigurationProtocolGuid, NULL, (VOID **)&PlatformToDriverInterface);
       if (EFI_ERROR (Status)) {
-        DEBUG ((EFI_D_ERROR, "%a, Could not locate Platform to Driver Config protocol %r\r\n", __FUNCTION__, Status));
+        DEBUG ((DEBUG_ERROR, "%a, Could not locate Platform to Driver Config protocol %r\r\n", __FUNCTION__, Status));
         return Status;
       }
 
@@ -240,7 +240,7 @@ DeviceDiscoveryNotify (
           (SdMmcParameterInfoGuid == NULL) ||
           (SdMmcParameterSize == 0))
       {
-        DEBUG ((EFI_D_ERROR, "%a, Failed to call Query %r\r\n", __FUNCTION__, Status));
+        DEBUG ((DEBUG_ERROR, "%a, Failed to call Query %r\r\n", __FUNCTION__, Status));
         return Status;
       }
 
@@ -276,7 +276,7 @@ DeviceDiscoveryNotify (
                                             EfiPlatformConfigurationActionNone
                                             );
       if (EFI_ERROR (Status)) {
-        DEBUG ((EFI_D_ERROR, "%a, Failed to call Response %r\r\n", __FUNCTION__, Status));
+        DEBUG ((DEBUG_ERROR, "%a, Failed to call Response %r\r\n", __FUNCTION__, Status));
         return Status;
       }
 
@@ -319,7 +319,7 @@ DeviceDiscoveryNotify (
         if (!EFI_ERROR (Status)) {
           Status = DeviceDiscoverySetClockFreq (ControllerHandle, ClockName, SD_MMC_MAX_CLOCK);
           if (EFI_ERROR (Status)) {
-            DEBUG ((EFI_D_ERROR, "%a, Failed to set clock frequency %r\r\n", __FUNCTION__, Status));
+            DEBUG ((DEBUG_ERROR, "%a, Failed to set clock frequency %r\r\n", __FUNCTION__, Status));
             return Status;
           }
 
@@ -327,7 +327,7 @@ DeviceDiscoveryNotify (
           Status = DeviceDiscoveryGetClockFreq (ControllerHandle, ClockName, &Rate);
           if (!EFI_ERROR (Status)) {
             if (Rate > SD_MMC_MAX_CLOCK) {
-              DEBUG ((EFI_D_ERROR, "%a: Clock rate %llu out of range for SDHCI\r\n", __FUNCTION__, Rate));
+              DEBUG ((DEBUG_ERROR, "%a: Clock rate %llu out of range for SDHCI\r\n", __FUNCTION__, Rate));
               return EFI_DEVICE_ERROR;
             }
 
@@ -369,7 +369,7 @@ DeviceDiscoveryNotify (
 
       Status = gBS->LocateProtocol (&gNVIDIARegulatorProtocolGuid, NULL, (VOID **)&RegulatorProtocol);
       if (EFI_ERROR (Status)) {
-        DEBUG ((EFI_D_ERROR, "%a, Failed to locate regulator protocol %r\r\n", __FUNCTION__, Status));
+        DEBUG ((DEBUG_ERROR, "%a, Failed to locate regulator protocol %r\r\n", __FUNCTION__, Status));
         return Status;
       }
 
@@ -382,7 +382,7 @@ DeviceDiscoveryNotify (
 
         Status = RegulatorProtocol->GetInfo (RegulatorProtocol, MmcRegulator, &RegulatorInfo);
         if (EFI_ERROR (Status)) {
-          DEBUG ((EFI_D_ERROR, "%a, Failed to get regulator info %x, %r\r\n", __FUNCTION__, MmcRegulator, Status));
+          DEBUG ((DEBUG_ERROR, "%a, Failed to get regulator info %x, %r\r\n", __FUNCTION__, MmcRegulator, Status));
           return Status;
         }
 
@@ -396,7 +396,7 @@ DeviceDiscoveryNotify (
           if (Microvolts != RegulatorInfo.CurrentMicrovolts) {
             Status = RegulatorProtocol->SetVoltage (RegulatorProtocol, MmcRegulator, Microvolts);
             if (EFI_ERROR (Status)) {
-              DEBUG ((EFI_D_ERROR, "%a, Failed to set regulator voltage %x, %u, %r\r\n", __FUNCTION__, MmcRegulator, Microvolts, Status));
+              DEBUG ((DEBUG_ERROR, "%a, Failed to set regulator voltage %x, %u, %r\r\n", __FUNCTION__, MmcRegulator, Microvolts, Status));
               return Status;
             }
           }
@@ -404,7 +404,7 @@ DeviceDiscoveryNotify (
           if (!RegulatorInfo.IsEnabled) {
             Status = RegulatorProtocol->Enable (RegulatorProtocol, MmcRegulator, TRUE);
             if (EFI_ERROR (Status)) {
-              DEBUG ((EFI_D_ERROR, "%a, Failed to enable regulator %x, %r\r\n", __FUNCTION__, MmcRegulator, Status));
+              DEBUG ((DEBUG_ERROR, "%a, Failed to enable regulator %x, %r\r\n", __FUNCTION__, MmcRegulator, Status));
               return Status;
             }
           }
@@ -415,14 +415,14 @@ DeviceDiscoveryNotify (
         UINT32  MmcRegulator = SdMmcInfo.VmmcRegulatorId;
         Status = RegulatorProtocol->GetInfo (RegulatorProtocol, MmcRegulator, &RegulatorInfo);
         if (EFI_ERROR (Status)) {
-          DEBUG ((EFI_D_ERROR, "%a, Failed to get regulator info %x, %r\r\n", __FUNCTION__, MmcRegulator, Status));
+          DEBUG ((DEBUG_ERROR, "%a, Failed to get regulator info %x, %r\r\n", __FUNCTION__, MmcRegulator, Status));
           return Status;
         }
 
         if (RegulatorInfo.IsAvailable) {
           Status = RegulatorProtocol->Enable (RegulatorProtocol, MmcRegulator, TRUE);
           if (EFI_ERROR (Status)) {
-            DEBUG ((EFI_D_ERROR, "%a, Failed to enable regulator %x, %r\r\n", __FUNCTION__, MmcRegulator, Status));
+            DEBUG ((DEBUG_ERROR, "%a, Failed to enable regulator %x, %r\r\n", __FUNCTION__, MmcRegulator, Status));
             return Status;
           }
         }

--- a/Silicon/NVIDIA/Drivers/TegraP2UDxe/TegraP2UDxe.c
+++ b/Silicon/NVIDIA/Drivers/TegraP2UDxe/TegraP2UDxe.c
@@ -75,7 +75,7 @@ AddMemoryRegion (
 
     Status = gDS->GetMemorySpaceDescriptor (ScanLocation, &MemorySpace);
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "%a: Failed to GetMemorySpaceDescriptor (0x%llx): %r.\r\n", __FUNCTION__, ScanLocation, Status));
+      DEBUG ((DEBUG_ERROR, "%a: Failed to GetMemorySpaceDescriptor (0x%llx): %r.\r\n", __FUNCTION__, ScanLocation, Status));
       return Status;
     }
 
@@ -88,7 +88,7 @@ AddMemoryRegion (
                       EFI_MEMORY_UC | EFI_MEMORY_RUNTIME
                       );
       if (EFI_ERROR (Status)) {
-        DEBUG ((EFI_D_ERROR, "%a: Failed to AddMemorySpace: (0x%llx, 0x%llx) %r.\r\n", __FUNCTION__, ScanLocation, OverlapSize, Status));
+        DEBUG ((DEBUG_ERROR, "%a: Failed to AddMemorySpace: (0x%llx, 0x%llx) %r.\r\n", __FUNCTION__, ScanLocation, OverlapSize, Status));
         return Status;
       }
 
@@ -98,7 +98,7 @@ AddMemoryRegion (
                       EFI_MEMORY_UC
                       );
       if (EFI_ERROR (Status)) {
-        DEBUG ((EFI_D_ERROR, "%a: Failed to SetMemorySpaceAttributes: (0x%llx, 0x%llx) %r.\r\n", __FUNCTION__, ScanLocation, OverlapSize, Status));
+        DEBUG ((DEBUG_ERROR, "%a: Failed to SetMemorySpaceAttributes: (0x%llx, 0x%llx) %r.\r\n", __FUNCTION__, ScanLocation, OverlapSize, Status));
         return Status;
       }
     }
@@ -180,12 +180,12 @@ TegraP2UInit (
 
   Entry = FindP2UEntry (&Private->TegraP2UList, P2UId);
   if (Entry == NULL) {
-    DEBUG ((EFI_D_ERROR, "%a: Failed to find P2U Entry\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Failed to find P2U Entry\n", __FUNCTION__));
     return EFI_NOT_FOUND;
   }
 
   DEBUG ((
-    EFI_D_VERBOSE,
+    DEBUG_VERBOSE,
     "%a: P2U Base Addr = 0x%08X\r\n",
     __FUNCTION__,
     Entry->BaseAddr
@@ -275,7 +275,7 @@ AddP2UEntries (
 
     ListEntry = AllocateZeroPool (sizeof (TEGRAP2U_LIST_ENTRY));
     if (NULL == ListEntry) {
-      DEBUG ((EFI_D_ERROR, "%a: Failed to allocate list entry\r\n", __FUNCTION__));
+      DEBUG ((DEBUG_ERROR, "%a: Failed to allocate list entry\r\n", __FUNCTION__));
       return EFI_OUT_OF_RESOURCES;
     }
 
@@ -292,14 +292,14 @@ AddP2UEntries (
                     &PropertySize
                     );
     if (RegProperty == NULL) {
-      DEBUG ((EFI_D_ERROR, "%a: Failed to find \"reg\" entry\r\n", __FUNCTION__));
+      DEBUG ((DEBUG_ERROR, "%a: Failed to find \"reg\" entry\r\n", __FUNCTION__));
       return EFI_NOT_FOUND;
     }
 
     CopyMem ((VOID *)&ListEntry->BaseAddr, RegProperty, sizeof (UINT32));
     ListEntry->BaseAddr = SwapBytes32 (ListEntry->BaseAddr);
     DEBUG ((
-      EFI_D_VERBOSE,
+      DEBUG_VERBOSE,
       "%a: P2U Base Addr = 0x%08X\r\n",
       __FUNCTION__,
       ListEntry->BaseAddr
@@ -308,7 +308,7 @@ AddP2UEntries (
     Status = AddMemoryRegion (ListEntry->BaseAddr, SIZE_64KB);
     if (EFI_ERROR (Status)) {
       DEBUG ((
-        EFI_D_ERROR,
+        DEBUG_ERROR,
         "%a: Failed to add region 0x%016lx, 0x%016lx: %r.\r\n",
         __FUNCTION__,
         ListEntry->BaseAddr,
@@ -356,13 +356,13 @@ BuildP2UNodes (
 
   Status = DtPlatformLoadDtb (&Private->DeviceTreeBase, &Private->DeviceTreeSize);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "%a failed to get device tree: %r\r\n", __FUNCTION__, Status));
+    DEBUG ((DEBUG_ERROR, "%a failed to get device tree: %r\r\n", __FUNCTION__, Status));
     return Status;
   }
 
   Status = AddP2UEntries (Private);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "%a failed to add P2U entries: %r\r\n", __FUNCTION__, Status));
+    DEBUG ((DEBUG_ERROR, "%a failed to add P2U entries: %r\r\n", __FUNCTION__, Status));
     return Status;
   }
 
@@ -391,7 +391,7 @@ TegraP2UDxeInitialize (
 
   Private = AllocatePool (sizeof (TEGRAP2U_DXE_PRIVATE));
   if (NULL == Private) {
-    DEBUG ((EFI_D_ERROR, "%a: Failed to allocate private data stucture: %r\r\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Failed to allocate private data stucture: %r\r\n", __FUNCTION__));
     return EFI_OUT_OF_RESOURCES;
   }
 
@@ -416,7 +416,7 @@ TegraP2UDxeInitialize (
    */
   Status = BuildP2UNodes (Private);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "%a: Failed to parse P2U instances data: %r\r\n", __FUNCTION__, Status));
+    DEBUG ((DEBUG_ERROR, "%a: Failed to parse P2U instances data: %r\r\n", __FUNCTION__, Status));
     goto ErrorBuildP2UNodes;
   }
 
@@ -427,7 +427,7 @@ TegraP2UDxeInitialize (
                   NULL
                   );
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "%a, Failed to install protocols: %r\r\n", __FUNCTION__, Status));
+    DEBUG ((DEBUG_ERROR, "%a, Failed to install protocols: %r\r\n", __FUNCTION__, Status));
     goto ErrorExit;
   }
 

--- a/Silicon/NVIDIA/Drivers/TegraPinControlDxe/TegraPinControlDxe.c
+++ b/Silicon/NVIDIA/Drivers/TegraPinControlDxe/TegraPinControlDxe.c
@@ -152,7 +152,7 @@ DeviceDiscoveryNotify (
                  );
       if (EFI_ERROR (Status)) {
         DEBUG ((
-          EFI_D_ERROR,
+          DEBUG_ERROR,
           "%a: Couldn't find PadCtl address range\n",
           __FUNCTION__
           ));

--- a/Silicon/NVIDIA/Drivers/TegraPlatformInit/TegraPlatformInitDxe.c
+++ b/Silicon/NVIDIA/Drivers/TegraPlatformInit/TegraPlatformInitDxe.c
@@ -189,7 +189,7 @@ SetCpuGpuDistanceInfoPcdsFromDtb (
     if (Property != NULL) {
       CpuToCpuDistance = SwapBytes32 (Property[0]);
       PcdSet32S (PcdCpuToCpuDistance, CpuToCpuDistance);
-      DEBUG ((EFI_D_INFO, "Cpu To Cpu Distance = 0x%X\n", PcdGet32 (PcdCpuToCpuDistance)));
+      DEBUG ((DEBUG_INFO, "Cpu To Cpu Distance = 0x%X\n", PcdGet32 (PcdCpuToCpuDistance)));
     } else {
       DEBUG ((DEBUG_ERROR, "Cpu To Cpu Distance not found, using 0x%X\n", PcdGet32 (PcdCpuToCpuDistance)));
     }
@@ -198,7 +198,7 @@ SetCpuGpuDistanceInfoPcdsFromDtb (
     if (Property != NULL) {
       GpuToGpuDistance = SwapBytes32 (Property[0]);
       PcdSet32S (PcdGpuToGpuDistance, GpuToGpuDistance);
-      DEBUG ((EFI_D_INFO, "Gpu To Gpu Distance = 0x%X\n", PcdGet32 (PcdGpuToGpuDistance)));
+      DEBUG ((DEBUG_INFO, "Gpu To Gpu Distance = 0x%X\n", PcdGet32 (PcdGpuToGpuDistance)));
     } else {
       DEBUG ((DEBUG_ERROR, "Gpu To Gpu Distance not found, using 0x%X\n", PcdGet32 (PcdGpuToGpuDistance)));
     }
@@ -207,7 +207,7 @@ SetCpuGpuDistanceInfoPcdsFromDtb (
     if (Property != NULL) {
       CpuToOtherGpuDistance = SwapBytes32 (Property[0]);
       PcdSet32S (PcdCpuToOtherGpuDistance, CpuToOtherGpuDistance);
-      DEBUG ((EFI_D_INFO, "Cpu To Other Gpu Distance = 0x%X\n", PcdGet32 (PcdCpuToOtherGpuDistance)));
+      DEBUG ((DEBUG_INFO, "Cpu To Other Gpu Distance = 0x%X\n", PcdGet32 (PcdCpuToOtherGpuDistance)));
     } else {
       DEBUG ((DEBUG_ERROR, "Cpu To Other Gpu Distance not found, using 0x%X\n", PcdGet32 (PcdCpuToOtherGpuDistance)));
     }
@@ -216,7 +216,7 @@ SetCpuGpuDistanceInfoPcdsFromDtb (
     if (Property != NULL) {
       CpuToOwnGpuDistance = SwapBytes32 (Property[0]);
       PcdSet32S (PcdCpuToOwnGpuDistance, CpuToOwnGpuDistance);
-      DEBUG ((EFI_D_INFO, "Cpu To Own Gpu Distance = 0x%X\n", PcdGet32 (PcdCpuToOwnGpuDistance)));
+      DEBUG ((DEBUG_INFO, "Cpu To Own Gpu Distance = 0x%X\n", PcdGet32 (PcdCpuToOwnGpuDistance)));
     } else {
       DEBUG ((DEBUG_ERROR, "Cpu To Own Gpu Distance not found, using 0x%X\n", PcdGet32 (PcdCpuToOwnGpuDistance)));
     }
@@ -225,7 +225,7 @@ SetCpuGpuDistanceInfoPcdsFromDtb (
     if (Property != NULL) {
       GpuToOtherCpuDistance = SwapBytes32 (Property[0]);
       PcdSet32S (PcdGpuToOtherCpuDistance, GpuToOtherCpuDistance);
-      DEBUG ((EFI_D_INFO, "Gpu To Other Cpu Distance = 0x%X\n", PcdGet32 (PcdGpuToOtherCpuDistance)));
+      DEBUG ((DEBUG_INFO, "Gpu To Other Cpu Distance = 0x%X\n", PcdGet32 (PcdGpuToOtherCpuDistance)));
     } else {
       DEBUG ((DEBUG_ERROR, "Gpu To Other Cpu Distance not found, using 0x%X\n", PcdGet32 (PcdGpuToOtherCpuDistance)));
     }
@@ -234,7 +234,7 @@ SetCpuGpuDistanceInfoPcdsFromDtb (
     if (Property != NULL) {
       GpuToOwnCpuDistance = SwapBytes32 (Property[0]);
       PcdSet32S (PcdGpuToOwnCpuDistance, GpuToOwnCpuDistance);
-      DEBUG ((EFI_D_INFO, "Gpu To Own Cpu Distance = 0x%X\n", PcdGet32 (PcdGpuToOwnCpuDistance)));
+      DEBUG ((DEBUG_INFO, "Gpu To Own Cpu Distance = 0x%X\n", PcdGet32 (PcdGpuToOwnCpuDistance)));
     } else {
       DEBUG ((DEBUG_ERROR, "Gpu To Own Cpu Distance not found, using 0x%X\n", PcdGet32 (PcdGpuToOwnCpuDistance)));
     }
@@ -270,7 +270,7 @@ SetGicInfoPcdsFromDtb (
   }
 
   if (!GetGicInfo (GicInfo)) {
-    Status = EFI_D_ERROR;
+    Status = DEBUG_ERROR;
     goto Exit;
   }
 
@@ -323,7 +323,7 @@ SetGicInfoPcdsFromDtb (
     PcdSet64S (PcdGicInterruptInterfaceBase, RegisterData[1].BaseAddress);
 
     DEBUG ((
-      EFI_D_INFO,
+      DEBUG_INFO,
       "Found GIC distributor and Interrupt Interface Base@ 0x%Lx (0x%Lx)\n",
       PcdGet64 (PcdGicDistributorBase),
       PcdGet64 (PcdGicInterruptInterfaceBase)
@@ -339,7 +339,7 @@ SetGicInfoPcdsFromDtb (
     // RegisterData[3] has GicV Base and Size
 
     DEBUG ((
-      EFI_D_INFO,
+      DEBUG_INFO,
       "Found GIC distributor and (re)distributor Base @ 0x%Lx (0x%Lx)\n",
       PcdGet64 (PcdGicDistributorBase),
       PcdGet64 (PcdGicRedistributorsBase)
@@ -468,7 +468,7 @@ TegraPlatformInitialize (
 
   Status = FloorSweepDtb (DtbBase);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "DTB floorsweeping failed.\n"));
+    DEBUG ((DEBUG_ERROR, "DTB floorsweeping failed.\n"));
     return Status;
   }
 

--- a/Silicon/NVIDIA/Drivers/UsbPadCtlDxe/UsbPadCtlDxe.c
+++ b/Silicon/NVIDIA/Drivers/UsbPadCtlDxe/UsbPadCtlDxe.c
@@ -90,7 +90,7 @@ DeviceDiscoveryNotify (
       Private = AllocatePool (sizeof (USBPADCTL_DXE_PRIVATE));
       if (NULL == Private) {
         DEBUG ((
-          EFI_D_ERROR,
+          DEBUG_ERROR,
           "%a: Failed to allocate private data stucture\r\n",
           __FUNCTION__
           ));
@@ -104,7 +104,7 @@ DeviceDiscoveryNotify (
                       );
       if (EFI_ERROR (Status) || (mRegulator == NULL)) {
         DEBUG ((
-          EFI_D_ERROR,
+          DEBUG_ERROR,
           "%a: Couldn't get gNVIDIARegulatorProtocolGuid Handle: %r\n",
           __FUNCTION__,
           Status
@@ -119,7 +119,7 @@ DeviceDiscoveryNotify (
                       );
       if (EFI_ERROR (Status) || (mEfuse == NULL)) {
         DEBUG ((
-          EFI_D_ERROR,
+          DEBUG_ERROR,
           "%a: Couldn't get gNVIDIAEFuseProtocolGuid Handle: %r\n",
           __FUNCTION__,
           Status
@@ -134,7 +134,7 @@ DeviceDiscoveryNotify (
                       );
       if (EFI_ERROR (Status) || (mClockProtocol == NULL)) {
         DEBUG ((
-          EFI_D_ERROR,
+          DEBUG_ERROR,
           "%a: Couldn't get gArmScmiClock2ProtocolGuid Handle: %r\n",
           __FUNCTION__,
           Status
@@ -171,7 +171,7 @@ DeviceDiscoveryNotify (
                       );
       if (EFI_ERROR (Status) || (mPmux == NULL)) {
         DEBUG ((
-          EFI_D_ERROR,
+          DEBUG_ERROR,
           "%a: Couldn't get gNVIDIAPinMuxProtocolGuid Handle: %r\n",
           __FUNCTION__,
           Status
@@ -190,7 +190,7 @@ DeviceDiscoveryNotify (
                    );
         if (EFI_ERROR (Status)) {
           DEBUG ((
-            EFI_D_ERROR,
+            DEBUG_ERROR,
             "%a: Unable to locate Xhci AO address range\n",
             __FUNCTION__
             ));
@@ -208,7 +208,7 @@ DeviceDiscoveryNotify (
                  );
       if (EFI_ERROR (Status)) {
         DEBUG ((
-          EFI_D_ERROR,
+          DEBUG_ERROR,
           "%a: Unable to locate UsbPadCtl Base address range\n",
           __FUNCTION__
           ));

--- a/Silicon/NVIDIA/Drivers/UsbPadCtlDxe/UsbPadCtlTegra194.c
+++ b/Silicon/NVIDIA/Drivers/UsbPadCtlDxe/UsbPadCtlTegra194.c
@@ -294,7 +294,7 @@ InitBiasPad (
     if (EFI_ERROR (Status)) {
       /* Print Error and Conitnue as USB3(Super Speed) might still be partially working */
       DEBUG ((
-        EFI_D_ERROR,
+        DEBUG_ERROR,
         "Unable to Enable USB2 Clock:%d Status: %x\n",
         PlatConfig->Usb2ClockIds[Index],
         Status
@@ -568,7 +568,7 @@ DisableVbus (
       /* Disable VBUS Regulator through GPIO */
       if (EFI_ERROR (mRegulator->Enable (mRegulator, Usb2Ports[i].VbusSupply, FALSE))) {
         DEBUG ((
-          EFI_D_ERROR,
+          DEBUG_ERROR,
           "%a: Couldn't Disable Regulator: %d for USB Port: %d\n",
           __FUNCTION__,
           Usb2Ports[i].VbusSupply,
@@ -611,7 +611,7 @@ EnableVbus (
       /* Enable VBUS Regulator through GPIO */
       if (EFI_ERROR (mRegulator->Enable (mRegulator, Usb2Ports[i].VbusSupply, TRUE))) {
         DEBUG ((
-          EFI_D_ERROR,
+          DEBUG_ERROR,
           "Couldn't Enable Regulator: %d for USB Port: %d\n",
           Usb2Ports[i].VbusSupply,
           i
@@ -632,14 +632,14 @@ EnableVbus (
   if (Private->HandleOverCurrent == TRUE) {
     Status = gBS->CreateEvent (EVT_TIMER | EVT_NOTIFY_SIGNAL, TPL_NOTIFY, OverCurrentHandler, Private, &Private->TimerEvent);
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "%a: Unable to create OverCurrent Timer\n", __FUNCTION__));
+      DEBUG ((DEBUG_ERROR, "%a: Unable to create OverCurrent Timer\n", __FUNCTION__));
       return Status;
     }
 
     /* Using 2 Seconds so that we dont load the System with frequent Polling */
     Status = gBS->SetTimer (Private->TimerEvent, TimerPeriodic, 20000000);
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "Error in Setting OverCurrent Timer\n"));
+      DEBUG ((DEBUG_ERROR, "Error in Setting OverCurrent Timer\n"));
       return Status;
     }
   }
@@ -660,24 +660,24 @@ FindUsb2PadClocks (
 
   NodeOffset = fdt_subnode_offset (DeviceTreeNode->DeviceTreeBase, DeviceTreeNode->NodeOffset, "pads");
   if (NodeOffset < 0) {
-    DEBUG ((EFI_D_ERROR, "%a: Couldn't find pads subnode in DT\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Couldn't find pads subnode in DT\n", __FUNCTION__));
     return EFI_UNSUPPORTED;
   }
 
   NodeOffset = fdt_subnode_offset (DeviceTreeNode->DeviceTreeBase, NodeOffset, "usb2");
   if (NodeOffset < 0) {
-    DEBUG ((EFI_D_ERROR, "%a: Couldn't find pads->usb2 subnode in DT\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Couldn't find pads->usb2 subnode in DT\n", __FUNCTION__));
     return EFI_UNSUPPORTED;
   }
 
   ClockIds = fdt_getprop (DeviceTreeNode->DeviceTreeBase, NodeOffset, "clocks", &ClocksLength);
   if ((ClockIds == 0) || (ClocksLength == 0)) {
     PlatConfig->NumUsb2Clocks = 0;
-    DEBUG ((EFI_D_ERROR, "%a: Couldn't find usb2 pad's clocks property in DT\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Couldn't find usb2 pad's clocks property in DT\n", __FUNCTION__));
     return EFI_UNSUPPORTED;
   } else {
     if ((ClocksLength % (sizeof (UINT32) * 2)) != 0) {
-      DEBUG ((EFI_D_ERROR, "%a, Clock length(%d) unexpected\n", __FUNCTION__, ClocksLength));
+      DEBUG ((DEBUG_ERROR, "%a, Clock length(%d) unexpected\n", __FUNCTION__, ClocksLength));
       return EFI_UNSUPPORTED;
     }
 
@@ -711,7 +711,7 @@ InitPlatInfo (
 
   Ports = AllocateZeroPool ((PlatConfig->NumHsPhys + PlatConfig->NumSsPhys) * sizeof (PORT_INFO));
   if (NULL == Ports) {
-    DEBUG ((EFI_D_ERROR, "%a: Failed to allocate Port Memory\r\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Failed to allocate Port Memory\r\n", __FUNCTION__));
     return EFI_OUT_OF_RESOURCES;
   }
 
@@ -722,7 +722,7 @@ InitPlatInfo (
   Usb3Ports = PlatConfig->Usb3Ports;
 
   if (FindUsb2PadClocks (PlatConfig, DeviceTreeNode) != EFI_SUCCESS) {
-    DEBUG ((EFI_D_ERROR, "Couldn't find USB2 Clocks Info in Device Tree\n"));
+    DEBUG ((DEBUG_ERROR, "Couldn't find USB2 Clocks Info in Device Tree\n"));
     FreePool (Ports);
     return EFI_UNSUPPORTED;
   }
@@ -730,7 +730,7 @@ InitPlatInfo (
   /* Finding the USB2 Ports that are enabled on the Platform */
   PortsOffset = fdt_subnode_offset (DeviceTreeNode->DeviceTreeBase, DeviceTreeNode->NodeOffset, "ports");
   if (PortsOffset < 0) {
-    DEBUG ((EFI_D_ERROR, "Couldn't find USB Ports\n"));
+    DEBUG ((DEBUG_ERROR, "Couldn't find USB Ports\n"));
     FreePool (Ports);
     return EFI_UNSUPPORTED;
   }
@@ -748,7 +748,7 @@ InitPlatInfo (
 
     Property = fdt_getprop (DeviceTreeNode->DeviceTreeBase, NodeOffset, "status", &PropertySize);
     if (Property == NULL) {
-      DEBUG ((EFI_D_ERROR, "Couldnt Find the USB Port Status\n"));
+      DEBUG ((DEBUG_ERROR, "Couldnt Find the USB Port Status\n"));
       continue;
     }
 
@@ -759,7 +759,7 @@ InitPlatInfo (
 
     Property = fdt_getprop (DeviceTreeNode->DeviceTreeBase, NodeOffset, "mode", &PropertySize);
     if (Property == NULL) {
-      DEBUG ((EFI_D_ERROR, "%a: Couldn't Find the %s Port Mode\n", __FUNCTION__, Name));
+      DEBUG ((DEBUG_ERROR, "%a: Couldn't Find the %s Port Mode\n", __FUNCTION__, Name));
       continue;
     }
 
@@ -773,7 +773,7 @@ InitPlatInfo (
     if ((Property != NULL) && (PropertySize == sizeof (UINT32))) {
       Usb2Ports[i].VbusSupply = SwapBytes32 (*(UINT32 *)Property);
     } else {
-      DEBUG ((EFI_D_ERROR, "Couldn't find Vbus Supply for Port: %a\n", Name));
+      DEBUG ((DEBUG_ERROR, "Couldn't find Vbus Supply for Port: %a\n", Name));
       continue;
     }
 
@@ -804,7 +804,7 @@ InitPlatInfo (
 
     Property = fdt_getprop (DeviceTreeNode->DeviceTreeBase, NodeOffset, "status", &PropertySize);
     if (Property == NULL) {
-      DEBUG ((EFI_D_ERROR, "%a: Couldnt Find the %a Port Status\n", __FUNCTION__, Name));
+      DEBUG ((DEBUG_ERROR, "%a: Couldnt Find the %a Port Status\n", __FUNCTION__, Name));
       continue;
     }
 
@@ -827,7 +827,7 @@ InitPlatInfo (
         continue;
       }
     } else {
-      DEBUG ((EFI_D_ERROR, "%a: Cant find USB2 Companion Port for %a\n", __FUNCTION__, Name));
+      DEBUG ((DEBUG_ERROR, "%a: Cant find USB2 Companion Port for %a\n", __FUNCTION__, Name));
       continue;
     }
 
@@ -836,7 +836,7 @@ InitPlatInfo (
      * in USB2 DT Entry and vbus wont be enabled unless USB2 port is enabled
      */
     if (Usb2Ports[Usb3Ports[i].CompanionPort].PortEnabled == FALSE) {
-      DEBUG ((EFI_D_ERROR, "%a:USB2 Companion Port for %a is not enabled in DT\n", __FUNCTION__, Name));
+      DEBUG ((DEBUG_ERROR, "%a:USB2 Companion Port for %a is not enabled in DT\n", __FUNCTION__, Name));
       continue;
     }
 
@@ -848,7 +848,7 @@ InitPlatInfo (
 
     /* Enable the USB3 Port as we got all the necessary Information */
     Usb3Ports[i].PortEnabled = TRUE;
-    DEBUG ((EFI_D_INFO, "Usb SS Port: %d Enabled\n", i));
+    DEBUG ((DEBUG_INFO, "Usb SS Port: %d Enabled\n", i));
   }
 
   /* If atleast one port is enabled, return Success */

--- a/Silicon/NVIDIA/Drivers/UsbPadCtlDxe/UsbPadCtlTegra234.c
+++ b/Silicon/NVIDIA/Drivers/UsbPadCtlDxe/UsbPadCtlTegra234.c
@@ -307,7 +307,7 @@ InitBiasPad (
     if (EFI_ERROR (Status)) {
       /* Print Error and Conitnue as USB3(Super Speed) might still be partially working */
       DEBUG ((
-        EFI_D_ERROR,
+        DEBUG_ERROR,
         "Unable to Enable USB2 Clock:%d Status: %x\n",
         PlatConfig->Usb2ClockIds[Index],
         Status
@@ -583,7 +583,7 @@ DisableVbus (
       /* Disable VBUS Regulator through GPIO */
       if (EFI_ERROR (mRegulator->Enable (mRegulator, Usb2Ports[i].VbusSupply, FALSE))) {
         DEBUG ((
-          EFI_D_ERROR,
+          DEBUG_ERROR,
           "%a: Couldn't Disable Regulator: %d for USB Port: %d\n",
           __FUNCTION__,
           Usb2Ports[i].VbusSupply,
@@ -626,7 +626,7 @@ EnableVbus (
       /* Enable VBUS Regulator through GPIO */
       if (EFI_ERROR (mRegulator->Enable (mRegulator, Usb2Ports[i].VbusSupply, TRUE))) {
         DEBUG ((
-          EFI_D_ERROR,
+          DEBUG_ERROR,
           "Couldn't Enable Regulator: %d for USB Port: %d\n",
           Usb2Ports[i].VbusSupply,
           i
@@ -647,14 +647,14 @@ EnableVbus (
   if (Private->HandleOverCurrent == TRUE) {
     Status = gBS->CreateEvent (EVT_TIMER | EVT_NOTIFY_SIGNAL, TPL_NOTIFY, OverCurrentHandler, Private, &Private->TimerEvent);
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "%a: Unable to create OverCurrent Timer\n", __FUNCTION__));
+      DEBUG ((DEBUG_ERROR, "%a: Unable to create OverCurrent Timer\n", __FUNCTION__));
       return Status;
     }
 
     /* Using 2 Seconds so that we dont load the System with frequent Polling */
     Status = gBS->SetTimer (Private->TimerEvent, TimerPeriodic, 20000000);
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "Error in Setting OverCurrent Timer\n"));
+      DEBUG ((DEBUG_ERROR, "Error in Setting OverCurrent Timer\n"));
       return Status;
     }
   }
@@ -675,24 +675,24 @@ FindUsb2PadClocks (
 
   NodeOffset = fdt_subnode_offset (DeviceTreeNode->DeviceTreeBase, DeviceTreeNode->NodeOffset, "pads");
   if (NodeOffset < 0) {
-    DEBUG ((EFI_D_ERROR, "%a: Couldn't find pads subnode in DT\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Couldn't find pads subnode in DT\n", __FUNCTION__));
     return EFI_UNSUPPORTED;
   }
 
   NodeOffset = fdt_subnode_offset (DeviceTreeNode->DeviceTreeBase, NodeOffset, "usb2");
   if (NodeOffset < 0) {
-    DEBUG ((EFI_D_ERROR, "%a: Couldn't find pads->usb2 subnode in DT\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Couldn't find pads->usb2 subnode in DT\n", __FUNCTION__));
     return EFI_UNSUPPORTED;
   }
 
   ClockIds = fdt_getprop (DeviceTreeNode->DeviceTreeBase, NodeOffset, "clocks", &ClocksLength);
   if ((ClockIds == 0) || (ClocksLength == 0)) {
     PlatConfig->NumUsb2Clocks = 0;
-    DEBUG ((EFI_D_ERROR, "%a: Couldn't find usb2 pad's clocks property in DT\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Couldn't find usb2 pad's clocks property in DT\n", __FUNCTION__));
     return EFI_UNSUPPORTED;
   } else {
     if ((ClocksLength % (sizeof (UINT32) * 2)) != 0) {
-      DEBUG ((EFI_D_ERROR, "%a, Clock length(%d) unexpected\n", __FUNCTION__, ClocksLength));
+      DEBUG ((DEBUG_ERROR, "%a, Clock length(%d) unexpected\n", __FUNCTION__, ClocksLength));
       return EFI_UNSUPPORTED;
     }
 
@@ -726,7 +726,7 @@ InitPlatInfo (
 
   Ports = AllocateZeroPool ((PlatConfig->NumHsPhys + PlatConfig->NumSsPhys) * sizeof (PORT_INFO));
   if (NULL == Ports) {
-    DEBUG ((EFI_D_ERROR, "%a: Failed to allocate Port Memory\r\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Failed to allocate Port Memory\r\n", __FUNCTION__));
     return EFI_OUT_OF_RESOURCES;
   }
 
@@ -737,7 +737,7 @@ InitPlatInfo (
   Usb3Ports = PlatConfig->Usb3Ports;
 
   if (FindUsb2PadClocks (PlatConfig, DeviceTreeNode) != EFI_SUCCESS) {
-    DEBUG ((EFI_D_ERROR, "Couldn't find USB2 Clocks Info in Device Tree\n"));
+    DEBUG ((DEBUG_ERROR, "Couldn't find USB2 Clocks Info in Device Tree\n"));
     FreePool (Ports);
     return EFI_UNSUPPORTED;
   }
@@ -745,7 +745,7 @@ InitPlatInfo (
   /* Finding the USB2 Ports that are enabled on the Platform */
   PortsOffset = fdt_subnode_offset (DeviceTreeNode->DeviceTreeBase, DeviceTreeNode->NodeOffset, "ports");
   if (PortsOffset < 0) {
-    DEBUG ((EFI_D_ERROR, "Couldn't find USB Ports\n"));
+    DEBUG ((DEBUG_ERROR, "Couldn't find USB Ports\n"));
     FreePool (Ports);
     return EFI_UNSUPPORTED;
   }
@@ -763,7 +763,7 @@ InitPlatInfo (
 
     Property = fdt_getprop (DeviceTreeNode->DeviceTreeBase, NodeOffset, "status", &PropertySize);
     if (Property == NULL) {
-      DEBUG ((EFI_D_ERROR, "Couldnt Find the USB Port Status\n"));
+      DEBUG ((DEBUG_ERROR, "Couldnt Find the USB Port Status\n"));
       continue;
     }
 
@@ -774,7 +774,7 @@ InitPlatInfo (
 
     Property = fdt_getprop (DeviceTreeNode->DeviceTreeBase, NodeOffset, "mode", &PropertySize);
     if (Property == NULL) {
-      DEBUG ((EFI_D_ERROR, "%a: Couldn't Find the %s Port Mode\n", __FUNCTION__, Name));
+      DEBUG ((DEBUG_ERROR, "%a: Couldn't Find the %s Port Mode\n", __FUNCTION__, Name));
       continue;
     }
 
@@ -788,7 +788,7 @@ InitPlatInfo (
     if ((Property != NULL) && (PropertySize == sizeof (UINT32))) {
       Usb2Ports[i].VbusSupply = SwapBytes32 (*(UINT32 *)Property);
     } else {
-      DEBUG ((EFI_D_ERROR, "Couldn't find Vbus Supply for Port: %a\n", Name));
+      DEBUG ((DEBUG_ERROR, "Couldn't find Vbus Supply for Port: %a\n", Name));
       continue;
     }
 
@@ -819,7 +819,7 @@ InitPlatInfo (
 
     Property = fdt_getprop (DeviceTreeNode->DeviceTreeBase, NodeOffset, "status", &PropertySize);
     if (Property == NULL) {
-      DEBUG ((EFI_D_ERROR, "%a: Couldnt Find the %a Port Status\n", __FUNCTION__, Name));
+      DEBUG ((DEBUG_ERROR, "%a: Couldnt Find the %a Port Status\n", __FUNCTION__, Name));
       continue;
     }
 
@@ -842,7 +842,7 @@ InitPlatInfo (
         continue;
       }
     } else {
-      DEBUG ((EFI_D_ERROR, "%a: Cant find USB2 Companion Port for %a\n", __FUNCTION__, Name));
+      DEBUG ((DEBUG_ERROR, "%a: Cant find USB2 Companion Port for %a\n", __FUNCTION__, Name));
       continue;
     }
 
@@ -851,7 +851,7 @@ InitPlatInfo (
      * in USB2 DT Entry and vbus wont be enabled unless USB2 port is enabled
      */
     if (Usb2Ports[Usb3Ports[i].CompanionPort].PortEnabled == FALSE) {
-      DEBUG ((EFI_D_ERROR, "%a:USB2 Companion Port for %a is not enabled in DT\n", __FUNCTION__, Name));
+      DEBUG ((DEBUG_ERROR, "%a:USB2 Companion Port for %a is not enabled in DT\n", __FUNCTION__, Name));
       continue;
     }
 
@@ -863,7 +863,7 @@ InitPlatInfo (
 
     /* Enable the USB3 Port as we got all the necessary Information */
     Usb3Ports[i].PortEnabled = TRUE;
-    DEBUG ((EFI_D_INFO, "Usb SS Port: %d Enabled\n", i));
+    DEBUG ((DEBUG_INFO, "Usb SS Port: %d Enabled\n", i));
   }
 
   /* If atleast one port is enabled, return Success */

--- a/Silicon/NVIDIA/Drivers/XhciControllerDxe/XhciControllerDxe.c
+++ b/Silicon/NVIDIA/Drivers/XhciControllerDxe/XhciControllerDxe.c
@@ -129,7 +129,7 @@ OnExitBootServices (
     if (PgState == CmdPgStateOn) {
       Status = PgProtocol->Assert (PgProtocol, PgProtocol->PowerGateId[Index]);
       if (EFI_ERROR (Status)) {
-        DEBUG ((EFI_D_ERROR, "Xhci Assert pg fail: %d\r\n", PgProtocol->PowerGateId[Index]));
+        DEBUG ((DEBUG_ERROR, "Xhci Assert pg fail: %d\r\n", PgProtocol->PowerGateId[Index]));
         return;
       }
     }
@@ -187,7 +187,7 @@ DeviceDiscoveryNotify (
 
       Private = AllocatePool (sizeof (XHCICONTROLLER_DXE_PRIVATE));
       if (NULL == Private) {
-        DEBUG ((EFI_D_ERROR, "%a: Failed to allocate memory\r\n", __FUNCTION__));
+        DEBUG ((DEBUG_ERROR, "%a: Failed to allocate memory\r\n", __FUNCTION__));
         return EFI_OUT_OF_RESOURCES;
       }
 
@@ -253,7 +253,7 @@ DeviceDiscoveryNotify (
                  );
       if (EFI_ERROR (Status)) {
         DEBUG ((
-          EFI_D_ERROR,
+          DEBUG_ERROR,
           "%a: Unable to locate Xhci Base address range\n",
           __FUNCTION__
           ));
@@ -270,7 +270,7 @@ DeviceDiscoveryNotify (
                  );
       if (EFI_ERROR (Status)) {
         DEBUG ((
-          EFI_D_ERROR,
+          DEBUG_ERROR,
           "%a: Unable to locate Xhci Config address range\n",
           __FUNCTION__
           ));
@@ -288,7 +288,7 @@ DeviceDiscoveryNotify (
                    );
         if (EFI_ERROR (Status)) {
           DEBUG ((
-            EFI_D_ERROR,
+            DEBUG_ERROR,
             "%a: Unable to locate Xhci Base 2 address range\n",
             __FUNCTION__
             ));
@@ -315,7 +315,7 @@ DeviceDiscoveryNotify (
                       );
       if (EFI_ERROR (Status)) {
         DEBUG ((
-          EFI_D_ERROR,
+          DEBUG_ERROR,
           "%a, Failed to install protocols: %r\r\n",
           __FUNCTION__,
           Status
@@ -325,35 +325,35 @@ DeviceDiscoveryNotify (
 
       Status = gBS->HandleProtocol (ControllerHandle, &gNVIDIAPowerGateNodeProtocolGuid, (VOID **)&PgProtocol);
       if (EFI_ERROR (Status)) {
-        DEBUG ((EFI_D_ERROR, "PowerGateNodeProtocol not found\r\n"));
+        DEBUG ((DEBUG_ERROR, "PowerGateNodeProtocol not found\r\n"));
         goto ErrorExit;
       }
 
       // Unpowergate XUSBA/XUSBC partition first in XHCI DT
       for (Index = 0; Index < PgProtocol->NumberOfPowerGates; Index++) {
-        DEBUG ((EFI_D_ERROR, "Deassert pg: %d\r\n", PgProtocol->PowerGateId[Index]));
+        DEBUG ((DEBUG_ERROR, "Deassert pg: %d\r\n", PgProtocol->PowerGateId[Index]));
         Status = PgProtocol->Deassert (PgProtocol, PgProtocol->PowerGateId[Index]);
         if (EFI_ERROR (Status)) {
-          DEBUG ((EFI_D_ERROR, "Deassert pg not found\r\n"));
+          DEBUG ((DEBUG_ERROR, "Deassert pg not found\r\n"));
           goto ErrorExit;
         }
       }
 
       // Powergate XUSBA/XUSBC partition again to make it in default state
       for (Index = 0; Index < PgProtocol->NumberOfPowerGates; Index++) {
-        DEBUG ((EFI_D_ERROR, "Assert pg: %d\r\n", PgProtocol->PowerGateId[Index]));
+        DEBUG ((DEBUG_ERROR, "Assert pg: %d\r\n", PgProtocol->PowerGateId[Index]));
         Status = PgProtocol->Assert (PgProtocol, PgProtocol->PowerGateId[Index]);
         if (EFI_ERROR (Status)) {
-          DEBUG ((EFI_D_ERROR, "Assert pg not found\r\n"));
+          DEBUG ((DEBUG_ERROR, "Assert pg not found\r\n"));
         }
       }
 
       // Only unpowergate XUSBA/XUSBC in XHCI DT
       for (Index = 0; Index < PgProtocol->NumberOfPowerGates; Index++) {
-        DEBUG ((EFI_D_ERROR, "Deassert pg: %d\r\n", PgProtocol->PowerGateId[Index]));
+        DEBUG ((DEBUG_ERROR, "Deassert pg: %d\r\n", PgProtocol->PowerGateId[Index]));
         Status = PgProtocol->Deassert (PgProtocol, PgProtocol->PowerGateId[Index]);
         if (EFI_ERROR (Status)) {
-          DEBUG ((EFI_D_ERROR, "Deassert pg not found\r\n"));
+          DEBUG ((DEBUG_ERROR, "Deassert pg not found\r\n"));
         }
       }
 
@@ -364,7 +364,7 @@ DeviceDiscoveryNotify (
                       );
       if (EFI_ERROR (Status) || (Private->mUsbPadCtlProtocol == NULL)) {
         DEBUG ((
-          EFI_D_ERROR,
+          DEBUG_ERROR,
           "%a: Couldn't find UsbPadCtl Protocol Handle %r\n",
           __FUNCTION__,
           Status
@@ -395,7 +395,7 @@ DeviceDiscoveryNotify (
       Status = Private->mUsbPadCtlProtocol->InitHw (Private->mUsbPadCtlProtocol);
       if (EFI_ERROR (Status)) {
         DEBUG ((
-          EFI_D_ERROR,
+          DEBUG_ERROR,
           "%a, Failed to Initailize USB HW: %r\r\n",
           __FUNCTION__,
           Status
@@ -459,7 +459,7 @@ DeviceDiscoveryNotify (
                       );
       if (EFI_ERROR (Status) || (Private->mUsbFwProtocol == NULL)) {
         DEBUG ((
-          EFI_D_ERROR,
+          DEBUG_ERROR,
           "%a: Couldn't find UsbFw Protocol Handle %r\n",
           __FUNCTION__,
           Status
@@ -474,7 +474,7 @@ DeviceDiscoveryNotify (
                  );
       if (EFI_ERROR (Status)) {
         DEBUG ((
-          EFI_D_ERROR,
+          DEBUG_ERROR,
           "%a, failed to load falcon firmware %r\r\n",
           __FUNCTION__,
           Status
@@ -496,8 +496,8 @@ DeviceDiscoveryNotify (
 skipXusbFwLoad:
       /* Return Error if CNR is not cleared or Host Controller Error is set */
       if (StatusRegister & (USBSTS_CNR | USBSTS_HCE)) {
-        DEBUG ((EFI_D_ERROR, "Usb Host Controller Initialization Failed\n"));
-        DEBUG ((EFI_D_ERROR, "UsbStatus: 0x%x Falcon CPUCTL: 0x%x\n", StatusRegister, FalconRead32 (FALCON_CPUCTL_0)));
+        DEBUG ((DEBUG_ERROR, "Usb Host Controller Initialization Failed\n"));
+        DEBUG ((DEBUG_ERROR, "UsbStatus: 0x%x Falcon CPUCTL: 0x%x\n", StatusRegister, FalconRead32 (FALCON_CPUCTL_0)));
         Status = EFI_DEVICE_ERROR;
         goto ErrorExit;
       }

--- a/Silicon/NVIDIA/Library/ConfigurationManagerLib/ConfigurationManagerGicLib.c
+++ b/Silicon/NVIDIA/Library/ConfigurationManagerLib/ConfigurationManagerGicLib.c
@@ -386,7 +386,7 @@ UpdateGicInfo (
   GicInfo = (TEGRA_GIC_INFO *)AllocatePool (sizeof (TEGRA_GIC_INFO));
 
   if (!GetGicInfo (GicInfo)) {
-    Status = EFI_D_ERROR;
+    Status = DEBUG_ERROR;
     goto Exit;
   }
 

--- a/Silicon/NVIDIA/Library/DeviceDiscoveryDriverLib/DeviceDiscoveryDriverLib.c
+++ b/Silicon/NVIDIA/Library/DeviceDiscoveryDriverLib/DeviceDiscoveryDriverLib.c
@@ -71,14 +71,14 @@ DeviceDiscoveryOnExitBootServices (
   if (gDeviceDiscoverDriverConfig.AutoDeassertPg) {
     Status = gBS->HandleProtocol (Controller, &gNVIDIAPowerGateNodeProtocolGuid, (VOID **)&PgProtocol);
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "%a, no Pg node protocol\r\n", __FUNCTION__));
+      DEBUG ((DEBUG_ERROR, "%a, no Pg node protocol\r\n", __FUNCTION__));
       return;
     }
 
     for (Index = 0; Index < PgProtocol->NumberOfPowerGates; Index++) {
       Status = PgProtocol->Assert (PgProtocol, PgProtocol->PowerGateId[Index]);
       if (EFI_ERROR (Status)) {
-        DEBUG ((EFI_D_ERROR, "%a, failed to assert Pg %x: %r\r\n", __FUNCTION__, PgProtocol->PowerGateId[Index], Status));
+        DEBUG ((DEBUG_ERROR, "%a, failed to assert Pg %x: %r\r\n", __FUNCTION__, PgProtocol->PowerGateId[Index], Status));
         return;
       }
     }
@@ -87,13 +87,13 @@ DeviceDiscoveryOnExitBootServices (
   if (gDeviceDiscoverDriverConfig.AutoEnableClocks) {
     Status = gBS->HandleProtocol (Controller, &gNVIDIAClockNodeProtocolGuid, (VOID **)&ClockProtocol);
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "%a, no clock node protocol\r\n", __FUNCTION__));
+      DEBUG ((DEBUG_ERROR, "%a, no clock node protocol\r\n", __FUNCTION__));
       return;
     }
 
     Status = ClockProtocol->DisableAll (ClockProtocol);
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "%a, failed to disable clocks %r\r\n", __FUNCTION__, Status));
+      DEBUG ((DEBUG_ERROR, "%a, failed to disable clocks %r\r\n", __FUNCTION__, Status));
       return;
     }
   }
@@ -101,25 +101,25 @@ DeviceDiscoveryOnExitBootServices (
   if (gDeviceDiscoverDriverConfig.AutoResetModule) {
     Status = gBS->HandleProtocol (Controller, &gNVIDIAResetNodeProtocolGuid, (VOID **)&ResetProtocol);
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "%a, no reset node protocol\r\n", __FUNCTION__));
+      DEBUG ((DEBUG_ERROR, "%a, no reset node protocol\r\n", __FUNCTION__));
       return;
     }
 
     Status = ResetProtocol->ModuleResetAll (ResetProtocol);
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "%a, failed to reset module%r\r\n", __FUNCTION__, Status));
+      DEBUG ((DEBUG_ERROR, "%a, failed to reset module%r\r\n", __FUNCTION__, Status));
       return;
     }
   } else if (gDeviceDiscoverDriverConfig.AutoDeassertReset) {
     Status = gBS->HandleProtocol (Controller, &gNVIDIAResetNodeProtocolGuid, (VOID **)&ResetProtocol);
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "%a, no reset node protocol\r\n", __FUNCTION__));
+      DEBUG ((DEBUG_ERROR, "%a, no reset node protocol\r\n", __FUNCTION__));
       return;
     }
 
     Status = ResetProtocol->AssertAll (ResetProtocol);
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "%a, failed to assert resets %r\r\n", __FUNCTION__, Status));
+      DEBUG ((DEBUG_ERROR, "%a, failed to assert resets %r\r\n", __FUNCTION__, Status));
       return;
     }
   }
@@ -249,7 +249,7 @@ DeviceDiscoveryBindingStart (
                   EFI_OPEN_PROTOCOL_BY_DRIVER
                   );
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "%a, no NonDiscoverableProtocol\r\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a, no NonDiscoverableProtocol\r\n", __FUNCTION__));
     return Status;
   }
 
@@ -269,21 +269,21 @@ DeviceDiscoveryBindingStart (
   }
 
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "%a, no guid mapping\r\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a, no guid mapping\r\n", __FUNCTION__));
     goto ErrorExit;
   }
 
   if (gDeviceDiscoverDriverConfig.AutoDeassertPg) {
     Status = gBS->HandleProtocol (Controller, &gNVIDIAPowerGateNodeProtocolGuid, (VOID **)&PgProtocol);
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "%a, no Pg node protocol\r\n", __FUNCTION__));
+      DEBUG ((DEBUG_ERROR, "%a, no Pg node protocol\r\n", __FUNCTION__));
       goto ErrorExit;
     }
 
     for (Index = 0; Index < PgProtocol->NumberOfPowerGates; Index++) {
       Status = PgProtocol->Deassert (PgProtocol, PgProtocol->PowerGateId[Index]);
       if (EFI_ERROR (Status)) {
-        DEBUG ((EFI_D_ERROR, "%a, failed to deassert Pg %x: %r\r\n", __FUNCTION__, PgProtocol->PowerGateId[Index], Status));
+        DEBUG ((DEBUG_ERROR, "%a, failed to deassert Pg %x: %r\r\n", __FUNCTION__, PgProtocol->PowerGateId[Index], Status));
         goto ErrorExit;
       }
     }
@@ -292,13 +292,13 @@ DeviceDiscoveryBindingStart (
   if (gDeviceDiscoverDriverConfig.AutoEnableClocks) {
     Status = gBS->HandleProtocol (Controller, &gNVIDIAClockNodeProtocolGuid, (VOID **)&ClockProtocol);
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "%a, no clock node protocol\r\n", __FUNCTION__));
+      DEBUG ((DEBUG_ERROR, "%a, no clock node protocol\r\n", __FUNCTION__));
       goto ErrorExit;
     }
 
     Status = ClockProtocol->EnableAll (ClockProtocol);
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "%a, failed to enable clocks %r\r\n", __FUNCTION__, Status));
+      DEBUG ((DEBUG_ERROR, "%a, failed to enable clocks %r\r\n", __FUNCTION__, Status));
       goto ErrorExit;
     }
   }
@@ -306,25 +306,25 @@ DeviceDiscoveryBindingStart (
   if (gDeviceDiscoverDriverConfig.AutoResetModule) {
     Status = gBS->HandleProtocol (Controller, &gNVIDIAResetNodeProtocolGuid, (VOID **)&ResetProtocol);
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "%a, no reset node protocol\r\n", __FUNCTION__));
+      DEBUG ((DEBUG_ERROR, "%a, no reset node protocol\r\n", __FUNCTION__));
       goto ErrorExit;
     }
 
     Status = ResetProtocol->ModuleResetAll (ResetProtocol);
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "%a, failed to reset module%r\r\n", __FUNCTION__, Status));
+      DEBUG ((DEBUG_ERROR, "%a, failed to reset module%r\r\n", __FUNCTION__, Status));
       goto ErrorExit;
     }
   } else if (gDeviceDiscoverDriverConfig.AutoDeassertReset) {
     Status = gBS->HandleProtocol (Controller, &gNVIDIAResetNodeProtocolGuid, (VOID **)&ResetProtocol);
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "%a, no reset node protocol\r\n", __FUNCTION__));
+      DEBUG ((DEBUG_ERROR, "%a, no reset node protocol\r\n", __FUNCTION__));
       goto ErrorExit;
     }
 
     Status = ResetProtocol->DeassertAll (ResetProtocol);
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "%a, failed to deassert resets %r\r\n", __FUNCTION__, Status));
+      DEBUG ((DEBUG_ERROR, "%a, failed to deassert resets %r\r\n", __FUNCTION__, Status));
       goto ErrorExit;
     }
   }
@@ -335,7 +335,7 @@ DeviceDiscoveryBindingStart (
                   (VOID **)&DeviceDiscoveryContext
                   );
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "%a, driver returned %r to allocate context\r\n", __FUNCTION__, Status));
+    DEBUG ((DEBUG_ERROR, "%a, driver returned %r to allocate context\r\n", __FUNCTION__, Status));
     goto ErrorExit;
   }
 
@@ -355,7 +355,7 @@ DeviceDiscoveryBindingStart (
                     &DeviceDiscoveryContext->OnExitBootServicesEvent
                     );
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "%a, driver returned %r to create event callback\r\n", __FUNCTION__, Status));
+      DEBUG ((DEBUG_ERROR, "%a, driver returned %r to create event callback\r\n", __FUNCTION__, Status));
       goto ErrorExit;
     }
   }
@@ -367,7 +367,7 @@ DeviceDiscoveryBindingStart (
              Node
              );
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "%a, driver returned %r to start notification\r\n", __FUNCTION__, Status));
+    DEBUG ((DEBUG_ERROR, "%a, driver returned %r to start notification\r\n", __FUNCTION__, Status));
     goto ErrorExit;
   }
 
@@ -378,7 +378,7 @@ DeviceDiscoveryBindingStart (
                   NULL
                   );
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "%a, driver returned %r to install device discovery context guid\r\n", __FUNCTION__, Status));
+    DEBUG ((DEBUG_ERROR, "%a, driver returned %r to install device discovery context guid\r\n", __FUNCTION__, Status));
     goto ErrorExit;
   }
 
@@ -528,7 +528,7 @@ DeviceDiscoveryBindingStop (
                   NULL
                   );
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "%a, driver returned %r to uninstall device discovery context guid\r\n", __FUNCTION__, Status));
+    DEBUG ((DEBUG_ERROR, "%a, driver returned %r to uninstall device discovery context guid\r\n", __FUNCTION__, Status));
     return Status;
   }
 
@@ -707,7 +707,7 @@ EnumerateDevices (
     DeviceHandle = NULL;
     Device       = (NON_DISCOVERABLE_DEVICE *)AllocatePool (sizeof (NON_DISCOVERABLE_DEVICE));
     if (Device == NULL) {
-      DEBUG ((EFI_D_ERROR, "%a: Failed to allocate device protocol.\r\n", __FUNCTION__));
+      DEBUG ((DEBUG_ERROR, "%a: Failed to allocate device protocol.\r\n", __FUNCTION__));
       return EFI_DEVICE_ERROR;
     }
 
@@ -789,7 +789,7 @@ DeviceDiscoveryDriverInitialize (
                );
 
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "%a: Failed to install driver binding protocol: %r\r\n", __FUNCTION__, Status));
+      DEBUG ((DEBUG_ERROR, "%a: Failed to install driver binding protocol: %r\r\n", __FUNCTION__, Status));
       return Status;
     }
   }

--- a/Silicon/NVIDIA/Library/DeviceDiscoveryDriverLib/DeviceDiscoveryDriverLibServices.c
+++ b/Silicon/NVIDIA/Library/DeviceDiscoveryDriverLib/DeviceDiscoveryDriverLibServices.c
@@ -227,20 +227,20 @@ DeviceDiscoveryConfigReset (
 
   Status = gBS->HandleProtocol (ControllerHandle, &gNVIDIAResetNodeProtocolGuid, (VOID **)&ResetNodeProtocol);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "%a, no reset node protocol\r\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a, no reset node protocol\r\n", __FUNCTION__));
     return Status;
   }
 
   if (Enable) {
     Status = ResetNodeProtocol->Assert (ResetNodeProtocol, ResetId);
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "%a, failed to assert resets %r\r\n", __FUNCTION__, Status));
+      DEBUG ((DEBUG_ERROR, "%a, failed to assert resets %r\r\n", __FUNCTION__, Status));
       return Status;
     }
   } else {
     Status = ResetNodeProtocol->Deassert (ResetNodeProtocol, ResetId);
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "%a, failed to deassert resets %r\r\n", __FUNCTION__, Status));
+      DEBUG ((DEBUG_ERROR, "%a, failed to deassert resets %r\r\n", __FUNCTION__, Status));
       return Status;
     }
   }

--- a/Silicon/NVIDIA/Library/DeviceDiscoveryLib/DeviceDiscoveryLib.c
+++ b/Silicon/NVIDIA/Library/DeviceDiscoveryLib/DeviceDiscoveryLib.c
@@ -64,7 +64,7 @@ AddMemoryRegion (
 
     Status = gDS->GetMemorySpaceDescriptor (ScanLocation, &MemorySpace);
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "%a: Failed to GetMemorySpaceDescriptor (0x%llx): %r.\r\n", __FUNCTION__, ScanLocation, Status));
+      DEBUG ((DEBUG_ERROR, "%a: Failed to GetMemorySpaceDescriptor (0x%llx): %r.\r\n", __FUNCTION__, ScanLocation, Status));
       return Status;
     }
 
@@ -77,7 +77,7 @@ AddMemoryRegion (
                       EFI_MEMORY_UC | EFI_MEMORY_RUNTIME
                       );
       if (EFI_ERROR (Status)) {
-        DEBUG ((EFI_D_ERROR, "%a: Failed to AddMemorySpace: (0x%llx, 0x%llx) %r.\r\n", __FUNCTION__, ScanLocation, OverlapSize, Status));
+        DEBUG ((DEBUG_ERROR, "%a: Failed to AddMemorySpace: (0x%llx, 0x%llx) %r.\r\n", __FUNCTION__, ScanLocation, OverlapSize, Status));
         return Status;
       }
 
@@ -87,7 +87,7 @@ AddMemoryRegion (
                       EFI_MEMORY_UC
                       );
       if (EFI_ERROR (Status)) {
-        DEBUG ((EFI_D_ERROR, "%a: Failed to SetMemorySpaceAttributes: (0x%llx, 0x%llx) %r.\r\n", __FUNCTION__, ScanLocation, OverlapSize, Status));
+        DEBUG ((DEBUG_ERROR, "%a: Failed to SetMemorySpaceAttributes: (0x%llx, 0x%llx) %r.\r\n", __FUNCTION__, ScanLocation, OverlapSize, Status));
         return Status;
       }
     }
@@ -153,7 +153,7 @@ GetResources (
       (SizeCells > 2) ||
       (SizeCells == 0))
   {
-    DEBUG ((EFI_D_ERROR, "%a: Bad cell values, %d, %d\r\n", __FUNCTION__, AddressCells, SizeCells));
+    DEBUG ((DEBUG_ERROR, "%a: Bad cell values, %d, %d\r\n", __FUNCTION__, AddressCells, SizeCells));
     return EFI_UNSUPPORTED;
   }
 
@@ -187,7 +187,7 @@ GetResources (
 
     AllocResources = (EFI_ACPI_ADDRESS_SPACE_DESCRIPTOR *)AllocateZeroPool (AllocationSize);
     if (NULL == AllocResources) {
-      DEBUG ((EFI_D_ERROR, "%a: Failed to allocate ACPI resources.\r\n", __FUNCTION__));
+      DEBUG ((DEBUG_ERROR, "%a: Failed to allocate ACPI resources.\r\n", __FUNCTION__));
       return EFI_OUT_OF_RESOURCES;
     }
   } else {
@@ -228,7 +228,7 @@ GetResources (
     Status = AddMemoryRegion (AddressBase, RegionSize);
     if (EFI_ERROR (Status)) {
       DEBUG ((
-        EFI_D_ERROR,
+        DEBUG_ERROR,
         "%a: Failed to add region 0x%016lx, 0x%016lx: %r.\r\n",
         __FUNCTION__,
         AddressBase,
@@ -252,7 +252,7 @@ GetResources (
 
     if (SharedMemOffset <= 0) {
       DEBUG ((
-        EFI_D_ERROR,
+        DEBUG_ERROR,
         "%a: Unable to locate shared memory handle %u\r\n",
         __FUNCTION__,
         Handle
@@ -265,7 +265,7 @@ GetResources (
     ParentOffset = fdt_parent_offset (DeviceTreeBase, SharedMemOffset);
     if (ParentOffset < 0) {
       DEBUG ((
-        EFI_D_ERROR,
+        DEBUG_ERROR,
         "%a: Unable to locate shared memory handle's parent %u\r\n",
         __FUNCTION__,
         Handle
@@ -283,7 +283,7 @@ GetResources (
         (SizeCells > 2) ||
         (SizeCells == 0))
     {
-      DEBUG ((EFI_D_ERROR, "%a: Bad cell values, %d, %d\r\n", __FUNCTION__, AddressCells, SizeCells));
+      DEBUG ((DEBUG_ERROR, "%a: Bad cell values, %d, %d\r\n", __FUNCTION__, AddressCells, SizeCells));
       return EFI_UNSUPPORTED;
     }
 
@@ -295,7 +295,7 @@ GetResources (
                     );
     if ((RegProperty == NULL) || (PropertySize == 0)) {
       DEBUG ((
-        EFI_D_ERROR,
+        DEBUG_ERROR,
         "%a: Invalid reg entry %p, %u, for handle %u\r\n",
         __FUNCTION__,
         RegProperty,
@@ -306,7 +306,7 @@ GetResources (
       EntrySize = sizeof (UINT32) * (AddressCells + SizeCells);
       ASSERT ((PropertySize % EntrySize) == 0);
       if (PropertySize != EntrySize) {
-        DEBUG ((EFI_D_ERROR, "%a: Ignoring secondary parent regions\r\n", __FUNCTION__));
+        DEBUG ((DEBUG_ERROR, "%a: Ignoring secondary parent regions\r\n", __FUNCTION__));
       }
 
       CopyMem ((VOID *)&ParentAddressBase, RegProperty, AddressCells * sizeof (UINT32));
@@ -325,7 +325,7 @@ GetResources (
         (SizeCells > 2) ||
         (SizeCells == 0))
     {
-      DEBUG ((EFI_D_ERROR, "%a: Bad cell values, %d, %d\r\n", __FUNCTION__, AddressCells, SizeCells));
+      DEBUG ((DEBUG_ERROR, "%a: Bad cell values, %d, %d\r\n", __FUNCTION__, AddressCells, SizeCells));
       return EFI_UNSUPPORTED;
     }
 
@@ -337,7 +337,7 @@ GetResources (
                     );
     if ((RegProperty == NULL) || (PropertySize == 0)) {
       DEBUG ((
-        EFI_D_ERROR,
+        DEBUG_ERROR,
         "%a: Invalid reg entry %p, %u, for handle %u\r\n",
         __FUNCTION__,
         RegProperty,
@@ -352,7 +352,7 @@ GetResources (
     EntrySize = sizeof (UINT32) * (AddressCells + SizeCells);
     ASSERT ((PropertySize % EntrySize) == 0);
     if (PropertySize != EntrySize) {
-      DEBUG ((EFI_D_ERROR, "%a: Ignoring secondary smem regions\r\n", __FUNCTION__));
+      DEBUG ((DEBUG_ERROR, "%a: Ignoring secondary smem regions\r\n", __FUNCTION__));
     }
 
     CopyMem ((VOID *)&AddressBase, RegProperty, AddressCells * sizeof (UINT32));
@@ -385,7 +385,7 @@ GetResources (
     Status = AddMemoryRegion (AddressBase, RegionSize);
     if (EFI_ERROR (Status)) {
       DEBUG ((
-        EFI_D_ERROR,
+        DEBUG_ERROR,
         "%a: Failed to add region 0x%016lx, 0x%016lx: %r.\r\n",
         __FUNCTION__,
         AddressBase,
@@ -759,7 +759,7 @@ GetResetNodeProtocol (
     NumberOfResets = 0;
   } else {
     if ((ResetsLength % (sizeof (UINT32) * 2)) != 0) {
-      DEBUG ((EFI_D_ERROR, "%a, Resets length unexpected %d\r\n", __FUNCTION__, ResetsLength));
+      DEBUG ((DEBUG_ERROR, "%a, Resets length unexpected %d\r\n", __FUNCTION__, ResetsLength));
       return;
     }
 
@@ -768,7 +768,7 @@ GetResetNodeProtocol (
 
   ResetNode = (NVIDIA_RESET_NODE_PROTOCOL *)AllocatePool (sizeof (NVIDIA_RESET_NODE_PROTOCOL) + (NumberOfResets * sizeof (NVIDIA_RESET_NODE_ENTRY)));
   if (NULL == ResetNode) {
-    DEBUG ((EFI_D_ERROR, "%a, Failed to allocate reset node\r\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a, Failed to allocate reset node\r\n", __FUNCTION__));
     return;
   }
 
@@ -957,7 +957,7 @@ GetClockNodeProtocol (
     NumberOfClocks = 0;
   } else {
     if ((ClocksLength % (sizeof (UINT32) * 2)) != 0) {
-      DEBUG ((EFI_D_ERROR, "%a, Clock length unexpected %d\r\n", __FUNCTION__, ClocksLength));
+      DEBUG ((DEBUG_ERROR, "%a, Clock length unexpected %d\r\n", __FUNCTION__, ClocksLength));
       return;
     }
 
@@ -966,7 +966,7 @@ GetClockNodeProtocol (
 
   ClockNode = (NVIDIA_CLOCK_NODE_PROTOCOL *)AllocatePool (sizeof (NVIDIA_CLOCK_NODE_PROTOCOL) + (NumberOfClocks * sizeof (NVIDIA_CLOCK_NODE_ENTRY)));
   if (NULL == ClockNode) {
-    DEBUG ((EFI_D_ERROR, "%a, Failed to allocate clock node\r\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a, Failed to allocate clock node\r\n", __FUNCTION__));
     return;
   }
 
@@ -1195,7 +1195,7 @@ GetPowerGateNodeProtocol (
   }
 
   if ((PgLength % (sizeof (UINT32) * 2)) != 0) {
-    DEBUG ((EFI_D_ERROR, "%a, Power Gate length unexpected %d\r\n", __FUNCTION__, PgLength));
+    DEBUG ((DEBUG_ERROR, "%a, Power Gate length unexpected %d\r\n", __FUNCTION__, PgLength));
     return;
   }
 
@@ -1203,7 +1203,7 @@ GetPowerGateNodeProtocol (
 
   PgNode = (NVIDIA_POWER_GATE_NODE_PROTOCOL *)AllocatePool (sizeof (NVIDIA_POWER_GATE_NODE_PROTOCOL) + (NumberOfPgs * sizeof (UINT32)));
   if (NULL == PgNode) {
-    DEBUG ((EFI_D_ERROR, "%a, Failed to allocate power gate node\r\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a, Failed to allocate power gate node\r\n", __FUNCTION__));
     return;
   }
 
@@ -1269,7 +1269,7 @@ ProcessDeviceTreeNodeWithHandle (
 
   Status = GetResources (DeviceInfo->DeviceTreeBase, DeviceInfo->NodeOffset, &Device->Resources);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "%a: Failed to get node resources: %r.\r\n", __FUNCTION__, Status));
+    DEBUG ((DEBUG_ERROR, "%a: Failed to get node resources: %r.\r\n", __FUNCTION__, Status));
     goto ErrorExit;
   }
 
@@ -1297,7 +1297,7 @@ ProcessDeviceTreeNodeWithHandle (
     if ((Device->Resources->Desc != ACPI_ADDRESS_SPACE_DESCRIPTOR) ||
         (Device->Resources->ResType != ACPI_ADDRESS_SPACE_TYPE_MEM))
     {
-      DEBUG ((EFI_D_ERROR, "%a: Invalid node resources.\r\n", __FUNCTION__));
+      DEBUG ((DEBUG_ERROR, "%a: Invalid node resources.\r\n", __FUNCTION__));
       goto ErrorExit;
     } else {
       DevicePath->MemMap.MemMap.Header.Type     = HARDWARE_DEVICE_PATH;
@@ -1317,7 +1317,7 @@ ProcessDeviceTreeNodeWithHandle (
 
   NodeProtocolCopy = AllocateCopyPool (sizeof (NodeProtocol), (VOID *)&NodeProtocol);
   if (NULL == NodeProtocolCopy) {
-    DEBUG ((EFI_D_ERROR, "%a: Failed to allocate node protocol.\r\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Failed to allocate node protocol.\r\n", __FUNCTION__));
     goto ErrorExit;
   }
 
@@ -1336,7 +1336,7 @@ ProcessDeviceTreeNodeWithHandle (
                   NULL
                   );
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "%a: Failed to get install protocols: %r.\r\n", __FUNCTION__, Status));
+    DEBUG ((DEBUG_ERROR, "%a: Failed to get install protocols: %r.\r\n", __FUNCTION__, Status));
     goto ErrorExit;
   }
 
@@ -1352,7 +1352,7 @@ ProcessDeviceTreeNodeWithHandle (
                     NULL
                     );
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "%a: Failed to get install optional protocols: %r.\r\n", __FUNCTION__, Status));
+      DEBUG ((DEBUG_ERROR, "%a: Failed to get install optional protocols: %r.\r\n", __FUNCTION__, Status));
       UINTN  ProtocolUninstallIndex = 0;
       for (ProtocolUninstallIndex = 0; ProtocolUninstallIndex < ProtocolIndex; ProtocolUninstallIndex++) {
         gBS->UninstallMultipleProtocolInterfaces (

--- a/Silicon/NVIDIA/Library/DeviceTreeHelperLib/DeviceTreeHelperLib.c
+++ b/Silicon/NVIDIA/Library/DeviceTreeHelperLib/DeviceTreeHelperLib.c
@@ -293,7 +293,7 @@ GetDeviceTreeRegisters (
       (SizeCells > 2) ||
       (SizeCells == 0))
   {
-    DEBUG ((EFI_D_ERROR, "%a: Bad cell values, %d, %d\r\n", __FUNCTION__, AddressCells, SizeCells));
+    DEBUG ((DEBUG_ERROR, "%a: Bad cell values, %d, %d\r\n", __FUNCTION__, AddressCells, SizeCells));
     return EFI_DEVICE_ERROR;
   }
 

--- a/Silicon/NVIDIA/Library/DramCarveoutLib/DramCarveoutLib.c
+++ b/Silicon/NVIDIA/Library/DramCarveoutLib/DramCarveoutLib.c
@@ -169,7 +169,7 @@ InstallDramWithCarveouts (
     );
   for (DramIndex = 0; DramIndex < DramRegionsCount; DramIndex++) {
     DEBUG ((
-      EFI_D_ERROR,
+      DEBUG_ERROR,
       "InstallDramWithCarveouts() Dram Region: Base: 0x%016lx, Size: 0x%016lx\n",
       DramRegions[DramIndex].MemoryBaseAddress,
       DramRegions[DramIndex].MemoryLength
@@ -186,7 +186,7 @@ InstallDramWithCarveouts (
     );
   for (CarveoutIndex = 0; CarveoutIndex < CarveoutRegionsCount; CarveoutIndex++) {
     DEBUG ((
-      EFI_D_ERROR,
+      DEBUG_ERROR,
       "InstallDramWithCarveouts() Carveout Region: Base: 0x%016lx, Size: 0x%016lx\n",
       CarveoutRegions[CarveoutIndex].MemoryBaseAddress,
       CarveoutRegions[CarveoutIndex].MemoryLength

--- a/Silicon/NVIDIA/Library/DxeDtPlatformDtbLoaderLib/DxeDtPlatformDtbLoaderLib.c
+++ b/Silicon/NVIDIA/Library/DxeDtPlatformDtbLoaderLib/DxeDtPlatformDtbLoaderLib.c
@@ -44,7 +44,7 @@ DtPlatformLoadDtb (
 
   if (fdt_check_header (*Dtb) != 0) {
     DEBUG ((
-      EFI_D_ERROR,
+      DEBUG_ERROR,
       "%a: No DTB found @ 0x%p\n",
       __FUNCTION__,
       *Dtb

--- a/Silicon/NVIDIA/Library/MaximRealTimeClockLib/MaximRealTimeClockLib.c
+++ b/Silicon/NVIDIA/Library/MaximRealTimeClockLib/MaximRealTimeClockLib.c
@@ -101,7 +101,7 @@ LibGetTime (
           RequestData.Operation[1].Flags         = I2C_FLAG_READ;
           Status                                 = mI2cIo->QueueRequest (mI2cIo, 0, NULL, RequestPacket, NULL);
           if (EFI_ERROR (Status)) {
-            DEBUG ((EFI_D_ERROR, "%a: Failed to get rtc register %02x: %r.\r\n", __FUNCTION__, Register, Status));
+            DEBUG ((DEBUG_ERROR, "%a: Failed to get rtc register %02x: %r.\r\n", __FUNCTION__, Register, Status));
             return EFI_DEVICE_ERROR;
           }
         }
@@ -128,7 +128,7 @@ LibGetTime (
         RequestData.Operation[1].Flags         = I2C_FLAG_READ;
         Status                                 = mI2cIo->QueueRequest (mI2cIo, MAXIM_I2C_ADDRESS_INDEX, NULL, RequestPacket, NULL);
         if (EFI_ERROR (Status)) {
-          DEBUG ((EFI_D_ERROR, "%a: Failed to get control register: %r.\r\n", __FUNCTION__, Status));
+          DEBUG ((DEBUG_ERROR, "%a: Failed to get control register: %r.\r\n", __FUNCTION__, Status));
           return EFI_DEVICE_ERROR;
         }
 
@@ -159,7 +159,7 @@ LibGetTime (
 
         Status = mI2cIo->QueueRequest (mI2cIo, MAXIM_I2C_ADDRESS_INDEX, NULL, RequestPacket, NULL);
         if (EFI_ERROR (Status)) {
-          DEBUG ((EFI_D_ERROR, "%a: Failed to request read update: %r.\r\n", __FUNCTION__, Status));
+          DEBUG ((DEBUG_ERROR, "%a: Failed to request read update: %r.\r\n", __FUNCTION__, Status));
           return EFI_DEVICE_ERROR;
         }
 
@@ -175,7 +175,7 @@ LibGetTime (
         RequestData.Operation[1].Flags         = I2C_FLAG_READ;
         Status                                 = mI2cIo->QueueRequest (mI2cIo, MAXIM_I2C_ADDRESS_INDEX, NULL, RequestPacket, NULL);
         if (EFI_ERROR (Status)) {
-          DEBUG ((EFI_D_ERROR, "%a: Failed to get time: %r.\r\n", __FUNCTION__, Status));
+          DEBUG ((DEBUG_ERROR, "%a: Failed to get time: %r.\r\n", __FUNCTION__, Status));
           return EFI_DEVICE_ERROR;
         }
 
@@ -341,7 +341,7 @@ LibSetTime (
       RequestData.Operation[1].Flags         = I2C_FLAG_READ;
       Status                                 = mI2cIo->QueueRequest (mI2cIo, 0, NULL, RequestPacket, NULL);
       if (EFI_ERROR (Status)) {
-        DEBUG ((EFI_D_ERROR, "%a: Failed to get rtc control register: %r.\r\n", __FUNCTION__, Status));
+        DEBUG ((DEBUG_ERROR, "%a: Failed to get rtc control register: %r.\r\n", __FUNCTION__, Status));
         return EFI_DEVICE_ERROR;
       }
 
@@ -364,7 +364,7 @@ LibSetTime (
           RequestData.Operation[1].Flags         = I2C_FLAG_READ;
           Status                                 = mI2cIo->QueueRequest (mI2cIo, 0, NULL, RequestPacket, NULL);
           if (EFI_ERROR (Status)) {
-            DEBUG ((EFI_D_ERROR, "%a: Failed to get rtc register %02x: %r.\r\n", __FUNCTION__, VrsBuffer[0], Status));
+            DEBUG ((DEBUG_ERROR, "%a: Failed to get rtc register %02x: %r.\r\n", __FUNCTION__, VrsBuffer[0], Status));
             return EFI_DEVICE_ERROR;
           }
         }
@@ -384,7 +384,7 @@ LibSetTime (
           RequestData.Operation[0].Flags         = WriteFlags;
           Status                                 = mI2cIo->QueueRequest (mI2cIo, 0, NULL, RequestPacket, NULL);
           if (EFI_ERROR (Status)) {
-            DEBUG ((EFI_D_ERROR, "%a: Failed to set rtc register %x: %r.\r\n", __FUNCTION__, VrsBuffer[0], Status));
+            DEBUG ((DEBUG_ERROR, "%a: Failed to set rtc register %x: %r.\r\n", __FUNCTION__, VrsBuffer[0], Status));
             return EFI_DEVICE_ERROR;
           }
         }
@@ -399,7 +399,7 @@ LibSetTime (
           RequestData.Operation[0].Flags         = WriteFlags;
           Status                                 = mI2cIo->QueueRequest (mI2cIo, 0, NULL, RequestPacket, NULL);
           if (EFI_ERROR (Status)) {
-            DEBUG ((EFI_D_ERROR, "%a: Failed to set rtc register %x: %r.\r\n", __FUNCTION__, VrsBuffer[0], Status));
+            DEBUG ((DEBUG_ERROR, "%a: Failed to set rtc register %x: %r.\r\n", __FUNCTION__, VrsBuffer[0], Status));
             return EFI_DEVICE_ERROR;
           }
         }
@@ -426,7 +426,7 @@ LibSetTime (
       TimeUpdate.Control.Reserved            = 0;
       Status                                 = mI2cIo->QueueRequest (mI2cIo, MAXIM_I2C_ADDRESS_INDEX, NULL, RequestPacket, NULL);
       if (EFI_ERROR (Status)) {
-        DEBUG ((EFI_D_ERROR, "%a: Failed to set control setting: %r.\r\n", __FUNCTION__, Status));
+        DEBUG ((DEBUG_ERROR, "%a: Failed to set control setting: %r.\r\n", __FUNCTION__, Status));
         return EFI_DEVICE_ERROR;
       }
 
@@ -454,7 +454,7 @@ LibSetTime (
 
       Status = mI2cIo->QueueRequest (mI2cIo, MAXIM_I2C_ADDRESS_INDEX, NULL, RequestPacket, NULL);
       if (EFI_ERROR (Status)) {
-        DEBUG ((EFI_D_ERROR, "%a: Failed to commit control settings: %r.\r\n", __FUNCTION__, Status));
+        DEBUG ((DEBUG_ERROR, "%a: Failed to commit control settings: %r.\r\n", __FUNCTION__, Status));
         return EFI_DEVICE_ERROR;
       }
 
@@ -472,7 +472,7 @@ LibSetTime (
       TimeUpdate.DateTime.Years              = Time->Year - MAXIM_BASE_YEAR;
       Status                                 = mI2cIo->QueueRequest (mI2cIo, MAXIM_I2C_ADDRESS_INDEX, NULL, RequestPacket, NULL);
       if (EFI_ERROR (Status)) {
-        DEBUG ((EFI_D_ERROR, "%a: Failed to store time: %r.\r\n", __FUNCTION__, Status));
+        DEBUG ((DEBUG_ERROR, "%a: Failed to store time: %r.\r\n", __FUNCTION__, Status));
         return EFI_DEVICE_ERROR;
       }
 
@@ -500,7 +500,7 @@ LibSetTime (
 
       Status = mI2cIo->QueueRequest (mI2cIo, MAXIM_I2C_ADDRESS_INDEX, NULL, RequestPacket, NULL);
       if (EFI_ERROR (Status)) {
-        DEBUG ((EFI_D_ERROR, "%a: Failed to commit time: %r.\r\n", __FUNCTION__, Status));
+        DEBUG ((DEBUG_ERROR, "%a: Failed to commit time: %r.\r\n", __FUNCTION__, Status));
         return EFI_DEVICE_ERROR;
       }
 
@@ -622,7 +622,7 @@ I2cIoRegistrationEvent (
                       (VOID **)&I2cIo
                       );
       if (EFI_ERROR (Status)) {
-        DEBUG ((EFI_D_ERROR, "%a: Failed to get i2c interface: %r", __FUNCTION__, Status));
+        DEBUG ((DEBUG_ERROR, "%a: Failed to get i2c interface: %r", __FUNCTION__, Status));
         continue;
       }
 
@@ -717,7 +717,7 @@ LibRtcInitialize (
             &mI2cIoSearchToken
             );
   if (Event == NULL) {
-    DEBUG ((EFI_D_ERROR, "%a: Failed to create protocol event\r\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Failed to create protocol event\r\n", __FUNCTION__));
     return EFI_OUT_OF_RESOURCES;
   }
 
@@ -733,7 +733,7 @@ LibRtcInitialize (
                   &mRtcExitBootServicesEvent
                   );
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "%a: Failed to create exit boot services event\r\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Failed to create exit boot services event\r\n", __FUNCTION__));
     gBS->CloseEvent (Event);
   }
 

--- a/Silicon/NVIDIA/Library/NuvotonRealTimeClockLib/NuvotonRealTimeClockLib.c
+++ b/Silicon/NVIDIA/Library/NuvotonRealTimeClockLib/NuvotonRealTimeClockLib.c
@@ -98,7 +98,7 @@ LibGetTime (
                                                sizeof (TimePacket.Control);
       Status = mI2cIo->QueueRequest (mI2cIo, 0, NULL, RequestPacket, NULL);
       if (EFI_ERROR (Status)) {
-        DEBUG ((EFI_D_ERROR, "%a: Failed to read time registers: %r.\r\n", __FUNCTION__, Status));
+        DEBUG ((DEBUG_ERROR, "%a: Failed to read time registers: %r.\r\n", __FUNCTION__, Status));
         return EFI_DEVICE_ERROR;
       }
 
@@ -106,7 +106,7 @@ LibGetTime (
       // If RTC is stopped, it is unusable.
       //
       if (TimePacket.Control.ST == NUVOTON_RTC_CONTROL_ST_STOP) {
-        DEBUG ((EFI_D_ERROR, "%a: RTC is stopped.\r\n", __FUNCTION__));
+        DEBUG ((DEBUG_ERROR, "%a: RTC is stopped.\r\n", __FUNCTION__));
         return EFI_DEVICE_ERROR;
       }
 
@@ -168,7 +168,7 @@ LibGetTime (
                                                  sizeof (WDayPacket.DayOfWeek);
         Status = mI2cIo->QueueRequest (mI2cIo, 0, NULL, RequestPacket, NULL);
         if (EFI_ERROR (Status)) {
-          DEBUG ((EFI_D_ERROR, "%a: Failed to program day of week register: %r.\r\n", __FUNCTION__, Status));
+          DEBUG ((DEBUG_ERROR, "%a: Failed to program day of week register: %r.\r\n", __FUNCTION__, Status));
         }
       }
 
@@ -316,7 +316,7 @@ LibSetTime (
 
     Status = mI2cIo->QueueRequest (mI2cIo, 0, NULL, RequestPacket, NULL);
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "%a: Failed to read control registers: %r.\r\n", __FUNCTION__, Status));
+      DEBUG ((DEBUG_ERROR, "%a: Failed to read control registers: %r.\r\n", __FUNCTION__, Status));
       return EFI_DEVICE_ERROR;
     }
 
@@ -324,7 +324,7 @@ LibSetTime (
     // If RTC is stopped, it is unusable.
     //
     if (ControlPacket.Control.ST == NUVOTON_RTC_CONTROL_ST_STOP) {
-      DEBUG ((EFI_D_ERROR, "%a: RTC is stopped.\r\n", __FUNCTION__));
+      DEBUG ((DEBUG_ERROR, "%a: RTC is stopped.\r\n", __FUNCTION__));
       return EFI_DEVICE_ERROR;
     }
 
@@ -334,7 +334,7 @@ LibSetTime (
     if (!PcdGetBool (PcdCpuHasRtcControl) &&
         (ControlPacket.Control.TWO == NUVOTON_RTC_CONTROL_TWO_PRIMARY))
     {
-      DEBUG ((EFI_D_ERROR, "%a: CPU is not holding the write ownership.\r\n", __FUNCTION__));
+      DEBUG ((DEBUG_ERROR, "%a: CPU is not holding the write ownership.\r\n", __FUNCTION__));
       return EFI_DEVICE_ERROR;
     }
 
@@ -390,7 +390,7 @@ LibSetTime (
                                              sizeof (TimePacket.DateTime);
     Status = mI2cIo->QueueRequest (mI2cIo, 0, NULL, RequestPacket, NULL);
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "%a: Failed to store time: %r.\r\n", __FUNCTION__, Status));
+      DEBUG ((DEBUG_ERROR, "%a: Failed to store time: %r.\r\n", __FUNCTION__, Status));
       return EFI_DEVICE_ERROR;
     }
 
@@ -532,7 +532,7 @@ LibRtcConfigure (
                                              sizeof (ControlPacket.Status);
     Status = mI2cIo->QueueRequest (mI2cIo, 0, NULL, RequestPacket, NULL);
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "%a: Failed to program control register: %r.\r\n", __FUNCTION__, Status));
+      DEBUG ((DEBUG_ERROR, "%a: Failed to program control register: %r.\r\n", __FUNCTION__, Status));
     }
 
     //
@@ -548,7 +548,7 @@ LibRtcConfigure (
                                              sizeof (PrimaryAccessPacket.PrimaryAccess);
     Status = mI2cIo->QueueRequest (mI2cIo, 0, NULL, RequestPacket, NULL);
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "%a: Failed to program primary access register: %r.\r\n", __FUNCTION__, Status));
+      DEBUG ((DEBUG_ERROR, "%a: Failed to program primary access register: %r.\r\n", __FUNCTION__, Status));
     }
   }
 }
@@ -595,7 +595,7 @@ I2cIoRegistrationEvent (
                       (VOID **)&I2cIo
                       );
       if (EFI_ERROR (Status)) {
-        DEBUG ((EFI_D_ERROR, "%a: Failed to get i2c interface: %r\n", __FUNCTION__, Status));
+        DEBUG ((DEBUG_ERROR, "%a: Failed to get i2c interface: %r\n", __FUNCTION__, Status));
         continue;
       }
 
@@ -682,7 +682,7 @@ LibRtcInitialize (
             &mI2cIoSearchToken
             );
   if (Event == NULL) {
-    DEBUG ((EFI_D_ERROR, "%a: Failed to create protocol event\r\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Failed to create protocol event\r\n", __FUNCTION__));
     return EFI_OUT_OF_RESOURCES;
   }
 
@@ -698,7 +698,7 @@ LibRtcInitialize (
                   &mRtcExitBootServicesEvent
                   );
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "%a: Failed to create exit boot services event\r\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Failed to create exit boot services event\r\n", __FUNCTION__));
     gBS->CloseEvent (Event);
     return EFI_OUT_OF_RESOURCES;
   }

--- a/Silicon/NVIDIA/Library/PciHostBridgeLib/PciHostBridgeLib.c
+++ b/Silicon/NVIDIA/Library/PciHostBridgeLib/PciHostBridgeLib.c
@@ -58,14 +58,14 @@ PciHostBridgeGetRootBridges (
                   &Handles
                   );
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "%a: Failed to locate host bridge protocols, %r.\r\n", __FUNCTION__, Status));
+    DEBUG ((DEBUG_ERROR, "%a: Failed to locate host bridge protocols, %r.\r\n", __FUNCTION__, Status));
     goto Done;
   }
 
   RootBridges = (PCI_ROOT_BRIDGE *)AllocatePool (sizeof (PCI_ROOT_BRIDGE) * NumberOfHandles);
   if (RootBridges == NULL) {
     Status = EFI_OUT_OF_RESOURCES;
-    DEBUG ((EFI_D_ERROR, "%a: Failed to allocate root bridge array.\r\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Failed to allocate root bridge array.\r\n", __FUNCTION__));
     goto Done;
   }
 
@@ -78,7 +78,7 @@ PciHostBridgeGetRootBridges (
                     );
     if (EFI_ERROR (Status)) {
       DEBUG ((
-        EFI_D_ERROR,
+        DEBUG_ERROR,
         "%a: Failed to get protocol for handle %p, %r.\r\n",
         __FUNCTION__,
         Handles[CurrentHandle],

--- a/Silicon/NVIDIA/Library/PlatformBootManagerLib/PlatformBm.c
+++ b/Silicon/NVIDIA/Library/PlatformBootManagerLib/PlatformBm.c
@@ -154,7 +154,7 @@ FilterAndProcess (
     // This is not an error, just an informative condition.
     //
     DEBUG ((
-      EFI_D_VERBOSE,
+      DEBUG_VERBOSE,
       "%a: %g: %r\n",
       __FUNCTION__,
       ProtocolGuid,
@@ -300,7 +300,7 @@ IsPciDisplay (
                         &Pci
                         );
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "%a: %s: %r\n", __FUNCTION__, ReportText, Status));
+    DEBUG ((DEBUG_ERROR, "%a: %s: %r\n", __FUNCTION__, ReportText, Status));
     return FALSE;
   }
 
@@ -328,7 +328,7 @@ Connect (
                   FALSE   // Recursive
                   );
   DEBUG ((
-    EFI_ERROR (Status) ? EFI_D_ERROR : EFI_D_VERBOSE,
+    EFI_ERROR (Status) ? DEBUG_ERROR : DEBUG_VERBOSE,
     "%a: %s: %r\n",
     __FUNCTION__,
     ReportText,
@@ -354,7 +354,7 @@ AddOutput (
   DevicePath = DevicePathFromHandle (Handle);
   if (DevicePath == NULL) {
     DEBUG ((
-      EFI_D_ERROR,
+      DEBUG_ERROR,
       "%a: %s: handle %p: device path not found\n",
       __FUNCTION__,
       ReportText,
@@ -366,7 +366,7 @@ AddOutput (
   Status = EfiBootManagerUpdateConsoleVariable (ConOut, DevicePath, NULL);
   if (EFI_ERROR (Status)) {
     DEBUG ((
-      EFI_D_ERROR,
+      DEBUG_ERROR,
       "%a: %s: adding to ConOut: %r\n",
       __FUNCTION__,
       ReportText,
@@ -378,7 +378,7 @@ AddOutput (
   Status = EfiBootManagerUpdateConsoleVariable (ErrOut, DevicePath, NULL);
   if (EFI_ERROR (Status)) {
     DEBUG ((
-      EFI_D_ERROR,
+      DEBUG_ERROR,
       "%a: %s: adding to ErrOut: %r\n",
       __FUNCTION__,
       ReportText,
@@ -388,7 +388,7 @@ AddOutput (
   }
 
   DEBUG ((
-    EFI_D_VERBOSE,
+    DEBUG_VERBOSE,
     "%a: %s: added to ConOut and ErrOut\n",
     __FUNCTION__,
     ReportText

--- a/Silicon/NVIDIA/Library/PlatformResourceLib/T194ResourceConfig.c
+++ b/Silicon/NVIDIA/Library/PlatformResourceLib/T194ResourceConfig.c
@@ -106,7 +106,7 @@ T194GetResourceConfig (
     }
 
     DEBUG ((
-      EFI_D_ERROR,
+      DEBUG_ERROR,
       "Carveout %d Region: Base: 0x%016lx, Size: 0x%016lx\n",
       Index,
       CpuBootloaderParams->CarveoutInfo[Index].Base,

--- a/Silicon/NVIDIA/Library/PlatformResourceLib/T234ResourceConfig.c
+++ b/Silicon/NVIDIA/Library/PlatformResourceLib/T234ResourceConfig.c
@@ -158,7 +158,7 @@ T234GetResourceConfig (
 
   // Build dram regions
   if (BanketDramEnabled) {
-    DEBUG ((EFI_D_ERROR, "DRAM Encryption Enabled\n"));
+    DEBUG ((DEBUG_ERROR, "DRAM Encryption Enabled\n"));
     // When blanket dram is enabled, uefi should use only memory in nsdram carveout
     // and interworld shmem carveout.
     DramRegions = (NVDA_MEMORY_REGION *)AllocatePool (2 * sizeof (NVDA_MEMORY_REGION));
@@ -175,7 +175,7 @@ T234GetResourceConfig (
     PlatformInfo->DramRegionsCount     = 2;
     PlatformInfo->UefiDramRegionsCount = 2;
   } else {
-    DEBUG ((EFI_D_ERROR, "DRAM Encryption Disabled\n"));
+    DEBUG ((DEBUG_ERROR, "DRAM Encryption Disabled\n"));
     DramRegions = (NVDA_MEMORY_REGION *)AllocatePool (sizeof (NVDA_MEMORY_REGION));
     ASSERT (DramRegions != NULL);
     if (DramRegions == NULL) {
@@ -204,7 +204,7 @@ T234GetResourceConfig (
     }
 
     DEBUG ((
-      EFI_D_ERROR,
+      DEBUG_ERROR,
       "Carveout %d Region: Base: 0x%016lx, Size: 0x%016lx\n",
       Index,
       CPUBL_PARAMS (CpuBootloaderParams, CarveoutInfo[Index].Base),

--- a/Silicon/NVIDIA/Library/QspiControllerLib/QspiControllerLib.c
+++ b/Silicon/NVIDIA/Library/QspiControllerLib/QspiControllerLib.c
@@ -70,7 +70,7 @@ QspiFlushFifo (
           if (Timeout == TIMEOUT) {
             Timeout = 0;
             if (TimeOutMessage == FALSE) {
-              DEBUG ((EFI_D_ERROR, "%a QSPI Transactions Slower Than Usual.\n", __FUNCTION__));
+              DEBUG ((DEBUG_ERROR, "%a QSPI Transactions Slower Than Usual.\n", __FUNCTION__));
               TimeOutMessage = TRUE;
             }
           }
@@ -105,7 +105,7 @@ QspiFlushFifo (
           if (Timeout == TIMEOUT) {
             Timeout = 0;
             if (TimeOutMessage == FALSE) {
-              DEBUG ((EFI_D_ERROR, "%a QSPI Transactions Slower Than Usual.\n", __FUNCTION__));
+              DEBUG ((DEBUG_ERROR, "%a QSPI Transactions Slower Than Usual.\n", __FUNCTION__));
               TimeOutMessage = TRUE;
             }
           }
@@ -150,7 +150,7 @@ QspiConfigureCS (
       );
   }
 
-  DEBUG ((EFI_D_INFO, "QSPI CS Configured.\n"));
+  DEBUG ((DEBUG_INFO, "QSPI CS Configured.\n"));
 }
 
 /**
@@ -214,7 +214,7 @@ QspiWaitTransactionStatusReady (
       if (Timeout == TIMEOUT) {
         Timeout = 0;
         if (TimeOutMessage == FALSE) {
-          DEBUG ((EFI_D_ERROR, "%a QSPI Transactions Slower Than Usual.\n", __FUNCTION__));
+          DEBUG ((DEBUG_ERROR, "%a QSPI Transactions Slower Than Usual.\n", __FUNCTION__));
           TimeOutMessage = TRUE;
         }
       }
@@ -368,7 +368,7 @@ QspiPerformReceive (
                                            QSPI_FIFO_STATUS_0_RX_FIFO_EMPTY_BIT
                                            ))
     {
-      DEBUG ((EFI_D_ERROR, "%a QSPI Rx FIFO Empty.\n", __FUNCTION__));
+      DEBUG ((DEBUG_ERROR, "%a QSPI Rx FIFO Empty.\n", __FUNCTION__));
       return EFI_DEVICE_ERROR;
     }
 
@@ -401,7 +401,7 @@ QspiPerformReceive (
     QSPI_COMMAND_0_PIO_DIS
     );
 
-  DEBUG ((EFI_D_INFO, "QSPI Data Received.\n"));
+  DEBUG ((DEBUG_INFO, "QSPI Data Received.\n"));
 
   return EFI_SUCCESS;
 }
@@ -458,7 +458,7 @@ QspiPerformTransmit (
                                           QSPI_FIFO_STATUS_0_TX_FIFO_FULL_BIT
                                           ))
     {
-      DEBUG ((EFI_D_ERROR, "%a QSPI Tx FIFO Full.\n", __FUNCTION__));
+      DEBUG ((DEBUG_ERROR, "%a QSPI Tx FIFO Full.\n", __FUNCTION__));
       return EFI_DEVICE_ERROR;
     }
 
@@ -504,7 +504,7 @@ QspiPerformTransmit (
     QSPI_COMMAND_0_PIO_DIS
     );
 
-  DEBUG ((EFI_D_INFO, "QSPI Data Transmitted.\n"));
+  DEBUG ((DEBUG_INFO, "QSPI Data Transmitted.\n"));
 
   return EFI_SUCCESS;
 }
@@ -589,7 +589,7 @@ QspiInitialize (
     return Status;
   }
 
-  DEBUG ((EFI_D_INFO, "QSPI Initialized.\n"));
+  DEBUG ((DEBUG_INFO, "QSPI Initialized.\n"));
 
   return EFI_SUCCESS;
 }
@@ -642,7 +642,7 @@ QspiPerformTransaction (
   QspiConfigureCS (QspiBaseAddress, TRUE);
   // If transmission buffer address valid, start transmission
   if (Packet->TxBuf != NULL) {
-    DEBUG ((EFI_D_INFO, "QSPI Tx Args: 0x%x %d.\n", Packet->TxBuf, Packet->TxLen));
+    DEBUG ((DEBUG_INFO, "QSPI Tx Args: 0x%x %d.\n", Packet->TxBuf, Packet->TxLen));
     Buffer = Packet->TxBuf;
     Count  = Packet->TxLen;
     // Based on transmission buffer length, calculate packet width and packets in current transaction.
@@ -650,7 +650,7 @@ QspiPerformTransaction (
     while (Count > 0) {
       TransactionWidth = (Count % sizeof (UINT32)) ? sizeof (UINT8) : sizeof (UINT32);
       TransactionCount = MIN (MAX_FIFO_PACKETS, (Count / TransactionWidth));
-      DEBUG ((EFI_D_INFO, "QSPI Tx Transaction: Count: %d Width: %d.\n", TransactionCount, TransactionWidth));
+      DEBUG ((DEBUG_INFO, "QSPI Tx Transaction: Count: %d Width: %d.\n", TransactionCount, TransactionWidth));
       Status = QspiPerformTransmit (QspiBaseAddress, Buffer, TransactionCount, TransactionWidth);
       if (EFI_ERROR (Status)) {
         return Status;
@@ -663,7 +663,7 @@ QspiPerformTransaction (
 
   // If reception buffer address valid, start reception
   if (Packet->RxBuf != NULL) {
-    DEBUG ((EFI_D_INFO, "QSPI Rx Args: 0x%x %d.\n", Packet->RxBuf, Packet->RxLen));
+    DEBUG ((DEBUG_INFO, "QSPI Rx Args: 0x%x %d.\n", Packet->RxBuf, Packet->RxLen));
     Buffer = Packet->RxBuf;
     Count  = Packet->RxLen;
     // Based on reception buffer length, calculate packet width and packets in current transaction.
@@ -671,7 +671,7 @@ QspiPerformTransaction (
     while (Count > 0) {
       TransactionWidth = (Count % sizeof (UINT32)) ? sizeof (UINT8) : sizeof (UINT32);
       TransactionCount = MIN (MAX_FIFO_PACKETS, (Count / TransactionWidth));
-      DEBUG ((EFI_D_INFO, "QSPI Rx Transaction: Count: %d Width: %d.\n", TransactionCount, TransactionWidth));
+      DEBUG ((DEBUG_INFO, "QSPI Rx Transaction: Count: %d Width: %d.\n", TransactionCount, TransactionWidth));
       Status = QspiPerformReceive (QspiBaseAddress, Buffer, TransactionCount, TransactionWidth);
       if (EFI_ERROR (Status)) {
         return Status;

--- a/Silicon/NVIDIA/Library/SeRngLib/SeRng.c
+++ b/Silicon/NVIDIA/Library/SeRngLib/SeRng.c
@@ -35,7 +35,7 @@ SeRngLibConstructor (
   Status = gBS->LocateProtocol (&gNVIDIASeRngProtocolGuid, NULL, (VOID **)&mRngProtocol);
 
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "%a: Failed to locate RNG protocol (%r)\r\n", __FUNCTION__, Status));
+    DEBUG ((DEBUG_ERROR, "%a: Failed to locate RNG protocol (%r)\r\n", __FUNCTION__, Status));
   }
 
   return Status;

--- a/Silicon/NVIDIA/Library/SystemResourceLib/SystemResourceLib.c
+++ b/Silicon/NVIDIA/Library/SystemResourceLib/SystemResourceLib.c
@@ -43,7 +43,7 @@ RegisterDeviceTree (
 
       EFI_PHYSICAL_ADDRESS  DtbCopy = (EFI_PHYSICAL_ADDRESS)AllocatePages (EFI_SIZE_TO_PAGES (DtbSize * 2));
       if (fdt_open_into ((VOID *)BlDtbLoadAddress, (VOID *)DtbCopy, 2 * DtbSize) != 0) {
-        DEBUG ((EFI_D_ERROR, "%a: Failed to increase device tree size\r\n", __FUNCTION__));
+        DEBUG ((DEBUG_ERROR, "%a: Failed to increase device tree size\r\n", __FUNCTION__));
         return;
       }
 
@@ -51,7 +51,7 @@ RegisterDeviceTree (
       if (fdt_check_header ((VOID *)DtbNext) == 0) {
         Status = ApplyTegraDeviceTreeOverlay ((VOID *)DtbCopy, (VOID *)DtbNext, SWModule);
         if (EFI_ERROR (Status)) {
-          DEBUG ((EFI_D_ERROR, "DTB Overlay failed. Using base DTB.\n"));
+          DEBUG ((DEBUG_ERROR, "DTB Overlay failed. Using base DTB.\n"));
           fdt_open_into ((VOID *)BlDtbLoadAddress, (VOID *)DtbCopy, 2 * DtbSize);
         }
       }
@@ -65,7 +65,7 @@ RegisterDeviceTree (
       if (NULL != DeviceTreeHobData) {
         *DeviceTreeHobData = DtbCopy;
       } else {
-        DEBUG ((EFI_D_ERROR, "Failed to build guid hob\r\n"));
+        DEBUG ((DEBUG_ERROR, "Failed to build guid hob\r\n"));
       }
     }
   }

--- a/Silicon/NVIDIA/Library/TegraDeviceTreeOverlayLib/TegraDeviceTreeOverlayLibCommon.c
+++ b/Silicon/NVIDIA/Library/TegraDeviceTreeOverlayLib/TegraDeviceTreeOverlayLibCommon.c
@@ -506,7 +506,7 @@ FdtCleanFixups (
   }
 
   if (fdt_open_into (FdtBase, FdtBuf, FdtSize)) {
-    DEBUG ((EFI_D_ERROR, "Failed to copy overlay device tree.\r\n"));
+    DEBUG ((DEBUG_ERROR, "Failed to copy overlay device tree.\r\n"));
     Status =  EFI_LOAD_ERROR;
     goto ExitFixups;
   }
@@ -774,7 +774,7 @@ ApplyTegraDeviceTreeOverlayCommon (
     FdtSize = fdt_totalsize (FdtNext);
 
     if (fdt_open_into (FdtNext, FdtBuf, FdtSize)) {
-      DEBUG ((EFI_D_ERROR, "Failed to copy overlay device tree.\r\n"));
+      DEBUG ((DEBUG_ERROR, "Failed to copy overlay device tree.\r\n"));
       Status =  EFI_LOAD_ERROR;
       goto Exit;
     }
@@ -786,12 +786,12 @@ ApplyTegraDeviceTreeOverlayCommon (
     if (EFI_SUCCESS == Status) {
       Err = fdt_overlay_apply (FdtBase, FdtBuf);
       if (Err != 0) {
-        DEBUG ((EFI_D_ERROR, "Failed to apply device tree overlay. Error Code = %d\n", Err));
+        DEBUG ((DEBUG_ERROR, "Failed to apply device tree overlay. Error Code = %d\n", Err));
         Status = EFI_DEVICE_ERROR;
         goto Exit;
       }
     } else {
-      DEBUG ((EFI_D_INFO, "Overlay skipped.\n"));
+      DEBUG ((DEBUG_INFO, "Overlay skipped.\n"));
       Status = EFI_SUCCESS;
     }
 

--- a/Silicon/NVIDIA/Library/UsbFalconLib/UsbFalconLib.c
+++ b/Silicon/NVIDIA/Library/UsbFalconLib/UsbFalconLib.c
@@ -82,14 +82,14 @@ FalconRead32 (
   UINT32  *Register32;
 
   if (XusbHostCfgAddr == 0) {
-    DEBUG ((EFI_D_ERROR, "%a:Invalid Xhci Config Address\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a:Invalid Xhci Config Address\n", __FUNCTION__));
     return 0;
   }
 
   Register32 = (UINT32 *)FalconMapReg (Address);
   UINT32  Value = MmioRead32 ((UINTN)Register32);
 
-  DEBUG ((EFI_D_VERBOSE, "%a: %x --> %x\r\n", __FUNCTION__, Address, Value));
+  DEBUG ((DEBUG_VERBOSE, "%a: %x --> %x\r\n", __FUNCTION__, Address, Value));
 
   return Value;
 }
@@ -103,13 +103,13 @@ FalconWrite32 (
   UINT32  *Register32;
 
   if (XusbHostCfgAddr == 0) {
-    DEBUG ((EFI_D_ERROR, "%a:Invalid Xhci Config Address\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a:Invalid Xhci Config Address\n", __FUNCTION__));
     return 0;
   }
 
   Register32 = (UINT32 *)FalconMapReg (Address);
 
-  DEBUG ((EFI_D_VERBOSE, "%a: %x <-- %x\r\n", __FUNCTION__, Address, Value));
+  DEBUG ((DEBUG_VERBOSE, "%a: %x <-- %x\r\n", __FUNCTION__, Address, Value));
 
   MmioWrite32 ((UINTN)Register32, Value);
 
@@ -124,14 +124,14 @@ Fpci2Read32 (
   UINT32  *Register32;
 
   if (XusbHostBase2Addr == 0) {
-    DEBUG ((EFI_D_ERROR, "%a:Invalid Xhci Config Address\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a:Invalid Xhci Config Address\n", __FUNCTION__));
     return 0;
   }
 
   Register32 = (UINT32 *)(XusbHostBase2Addr + Address);
   UINT32  Value = MmioRead32 ((UINTN)Register32);
 
-  DEBUG ((EFI_D_VERBOSE, "%a: %x --> %x\r\n", __FUNCTION__, Address, Value));
+  DEBUG ((DEBUG_VERBOSE, "%a: %x --> %x\r\n", __FUNCTION__, Address, Value));
 
   return Value;
 }
@@ -145,12 +145,12 @@ Fpci2Write32 (
   UINT32  *Register32;
 
   if (XusbHostBase2Addr == 0) {
-    DEBUG ((EFI_D_ERROR, "%a:Invalid Xhci Config Address\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a:Invalid Xhci Config Address\n", __FUNCTION__));
     return 0;
   }
 
   Register32 = (UINT32 *)(XusbHostBase2Addr + Address);
-  DEBUG ((EFI_D_VERBOSE, "%a: %x <-- %x\r\n", __FUNCTION__, Address, Value));
+  DEBUG ((DEBUG_VERBOSE, "%a: %x <-- %x\r\n", __FUNCTION__, Address, Value));
 
   MmioWrite32 ((UINTN)Register32, Value);
 
@@ -169,7 +169,7 @@ FalconDumpDMEM (
   FalconWrite32 (0x1c0, Value);
   for (i = 0; i < 16; i++) {
     Value = FalconRead32 (0x1c4);
-    DEBUG ((EFI_D_VERBOSE, "%a: [%d] 0x1c4 = %x\r\n", __FUNCTION__, i, Value));
+    DEBUG ((DEBUG_VERBOSE, "%a: [%d] 0x1c4 = %x\r\n", __FUNCTION__, i, Value));
   }
 }
 
@@ -192,20 +192,20 @@ FalconFirmwareIfrLoad (
   Value  = 0;
 
   if (XusbAoAddr == 0) {
-    DEBUG ((EFI_D_ERROR, "%a: XUSB AO Address is not init\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: XUSB AO Address is not init\n", __FUNCTION__));
     return EFI_INVALID_PARAMETER;
   }
 
   Value = FalconRead32 (XUSB_CSB_MEMPOOL_IDIRECT_PC);
   if (Value != 0) {
-    DEBUG ((EFI_D_ERROR, "%a: XUSB FW is loaded before, Failed: %r\n", __FUNCTION__, Status));
+    DEBUG ((DEBUG_ERROR, "%a: XUSB FW is loaded before, Failed: %r\n", __FUNCTION__, Status));
     return Status;
   }
 
   Pages  = EFI_SIZE_TO_PAGES (FirmwareSize);
   Status = DmaAllocateAlignedBuffer (EfiRuntimeServicesData, Pages, 256, (void **)&FirmwareBuffer);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "%a: DmaAllocateAlignedBuffer Failed: %r\n", __FUNCTION__, Status));
+    DEBUG ((DEBUG_ERROR, "%a: DmaAllocateAlignedBuffer Failed: %r\n", __FUNCTION__, Status));
     return Status;
   }
 
@@ -218,23 +218,23 @@ FalconFirmwareIfrLoad (
                  &FirmwareBufferMapping
                  );
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "%a: DmaMap Failed: %r\n", __FUNCTION__, Status));
+    DEBUG ((DEBUG_ERROR, "%a: DmaMap Failed: %r\n", __FUNCTION__, Status));
     return Status;
   }
 
-  DEBUG ((EFI_D_ERROR, "%a: Firmware %p FirmwareSize %x (unaligned)\r\n", __FUNCTION__, Firmware, FirmwareSize));
+  DEBUG ((DEBUG_ERROR, "%a: Firmware %p FirmwareSize %x (unaligned)\r\n", __FUNCTION__, Firmware, FirmwareSize));
   SetMem (FirmwareBuffer, BufferSize, 0xdf);
   CopyMem (FirmwareBuffer, Firmware, FirmwareSize);
   for (i = 0; i < FirmwareSize; i++) {
     if (FirmwareBuffer[i] != Firmware[i]) {
-      DEBUG ((EFI_D_ERROR, "%a: FirmwareBuffer[%d] != Firmware[%d]\r\n", __FUNCTION__, i, i));
+      DEBUG ((DEBUG_ERROR, "%a: FirmwareBuffer[%d] != Firmware[%d]\r\n", __FUNCTION__, i, i));
       return Status;
     }
   }
 
   MemoryFence ();
   Firmware = FirmwareBuffer;
-  DEBUG ((EFI_D_ERROR, "%a: Firmware %p FirmwareSize %x (aligned)\r\n", __FUNCTION__, Firmware, FirmwareSize));
+  DEBUG ((DEBUG_ERROR, "%a: Firmware %p FirmwareSize %x (aligned)\r\n", __FUNCTION__, Firmware, FirmwareSize));
 
   #define XUSB_BAR2_ARU_IFRDMA_CFG0            0x1bc
   #define XUSB_BAR2_ARU_IFRDMA_CFG1            0x1c0
@@ -282,7 +282,7 @@ FalconFirmwareLoad (
   UINTN                        FirmwareBufferBusAddress;
   VOID                         *FirmwareBufferMapping;
 
-  DEBUG ((EFI_D_VERBOSE, "%a\r\n", __FUNCTION__));
+  DEBUG ((DEBUG_VERBOSE, "%a\r\n", __FUNCTION__));
 
   if (LoadIfrRom == TRUE) {
     Status = FalconFirmwareIfrLoad (Firmware, FirmwareSize);
@@ -293,14 +293,14 @@ FalconFirmwareLoad (
   Value = FalconRead32 (XUSB_CSB_MEMPOOL_ILOAD_BASE_LO_0);
   if (Value != 0) {
     Value = FalconRead32 (FALCON_CPUCTL_0);
-    DEBUG ((EFI_D_VERBOSE, "%s: firmware already running cpu state %x\r\n", __FUNCTION__, Value));
+    DEBUG ((DEBUG_VERBOSE, "%s: firmware already running cpu state %x\r\n", __FUNCTION__, Value));
     return Status;
   }
 
   Pages  = EFI_SIZE_TO_PAGES (FirmwareSize);
   Status = DmaAllocateAlignedBuffer (EfiRuntimeServicesData, Pages, 256, (void **)&FirmwareBuffer);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "%a: DmaAllocateAlignedBuffer Failed: %r\n", __FUNCTION__, Status));
+    DEBUG ((DEBUG_ERROR, "%a: DmaAllocateAlignedBuffer Failed: %r\n", __FUNCTION__, Status));
     return Status;
   }
 
@@ -313,59 +313,59 @@ FalconFirmwareLoad (
                  &FirmwareBufferMapping
                  );
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "%a: DmaMap Failed: %r\n", __FUNCTION__, Status));
+    DEBUG ((DEBUG_ERROR, "%a: DmaMap Failed: %r\n", __FUNCTION__, Status));
     return Status;
   }
 
-  DEBUG ((EFI_D_VERBOSE, "%a: Firmware %p FirmwareSize %x (unaligned)\r\n", __FUNCTION__, Firmware, FirmwareSize));
+  DEBUG ((DEBUG_VERBOSE, "%a: Firmware %p FirmwareSize %x (unaligned)\r\n", __FUNCTION__, Firmware, FirmwareSize));
   SetMem (FirmwareBuffer, BufferSize, 0xdf);
   CopyMem (FirmwareBuffer, Firmware, FirmwareSize);
   for (i = 0; i < FirmwareSize; i++) {
     if (FirmwareBuffer[i] != Firmware[i]) {
-      DEBUG ((EFI_D_VERBOSE, "%a: FirmwareBuffer[%d] != Firmware[%d]\r\n", __FUNCTION__, i, i));
+      DEBUG ((DEBUG_VERBOSE, "%a: FirmwareBuffer[%d] != Firmware[%d]\r\n", __FUNCTION__, i, i));
       return Status;
     }
   }
 
   MemoryFence ();
   Firmware = FirmwareBuffer;
-  DEBUG ((EFI_D_VERBOSE, "%a: Firmware %p FirmwareSize %x (aligned)\r\n", __FUNCTION__, Firmware, FirmwareSize));
+  DEBUG ((DEBUG_VERBOSE, "%a: Firmware %p FirmwareSize %x (aligned)\r\n", __FUNCTION__, Firmware, FirmwareSize));
 
   /* Configure FW */
   FirmwareCfg = (struct tegra_xhci_fw_cfgtbl *)Firmware;
-  DEBUG ((EFI_D_VERBOSE, "%a: %x %x\r\n", __FUNCTION__, Firmware[0], Firmware[1]));
-  DEBUG ((EFI_D_VERBOSE, "%a: %x %x\r\n", __FUNCTION__, Firmware[2], Firmware[3]));
-  DEBUG ((EFI_D_VERBOSE, "%a: FirmwareCfg %p ss_portmap %x\r\n", __FUNCTION__, FirmwareCfg, FirmwareCfg->ss_portmap));
+  DEBUG ((DEBUG_VERBOSE, "%a: %x %x\r\n", __FUNCTION__, Firmware[0], Firmware[1]));
+  DEBUG ((DEBUG_VERBOSE, "%a: %x %x\r\n", __FUNCTION__, Firmware[2], Firmware[3]));
+  DEBUG ((DEBUG_VERBOSE, "%a: FirmwareCfg %p ss_portmap %x\r\n", __FUNCTION__, FirmwareCfg, FirmwareCfg->ss_portmap));
   FirmwareCfg->ss_portmap = 0xff;
-  DEBUG ((EFI_D_VERBOSE, "%a: FirmwareCfg %p ss_portmap %x\r\n", __FUNCTION__, FirmwareCfg, FirmwareCfg->ss_portmap));
-  DEBUG ((EFI_D_VERBOSE, "%a: FirmwareCfg %p num_hsic_port %x\r\n", __FUNCTION__, FirmwareCfg, FirmwareCfg->num_hsic_port));
+  DEBUG ((DEBUG_VERBOSE, "%a: FirmwareCfg %p ss_portmap %x\r\n", __FUNCTION__, FirmwareCfg, FirmwareCfg->ss_portmap));
+  DEBUG ((DEBUG_VERBOSE, "%a: FirmwareCfg %p num_hsic_port %x\r\n", __FUNCTION__, FirmwareCfg, FirmwareCfg->num_hsic_port));
   FirmwareCfg->num_hsic_port = 0;
-  DEBUG ((EFI_D_VERBOSE, "%a: FirmwareCfg %p num_hsic_port %x\r\n", __FUNCTION__, FirmwareCfg, FirmwareCfg->num_hsic_port));
-  DEBUG ((EFI_D_VERBOSE, "%a: FirmwareCfg %p boot_codetag %x\r\n", __FUNCTION__, FirmwareCfg, FirmwareCfg->boot_codetag));
-  DEBUG ((EFI_D_VERBOSE, "%a: FirmwareCfg %p boot_codesize %x\r\n", __FUNCTION__, FirmwareCfg, FirmwareCfg->boot_codesize));
-  DEBUG ((EFI_D_VERBOSE, "%a: FirmwareCfg %p fwimg_len %x\r\n", __FUNCTION__, FirmwareCfg, FirmwareCfg->fwimg_len));
+  DEBUG ((DEBUG_VERBOSE, "%a: FirmwareCfg %p num_hsic_port %x\r\n", __FUNCTION__, FirmwareCfg, FirmwareCfg->num_hsic_port));
+  DEBUG ((DEBUG_VERBOSE, "%a: FirmwareCfg %p boot_codetag %x\r\n", __FUNCTION__, FirmwareCfg, FirmwareCfg->boot_codetag));
+  DEBUG ((DEBUG_VERBOSE, "%a: FirmwareCfg %p boot_codesize %x\r\n", __FUNCTION__, FirmwareCfg, FirmwareCfg->boot_codesize));
+  DEBUG ((DEBUG_VERBOSE, "%a: FirmwareCfg %p fwimg_len %x\r\n", __FUNCTION__, FirmwareCfg, FirmwareCfg->fwimg_len));
 
   /* program system memory address where FW code starts */
   FirmwareAddress = FirmwareBufferBusAddress + sizeof (*FirmwareCfg);
   SIZE            = FirmwareSize / 256;
-  DEBUG ((EFI_D_VERBOSE, "%a: SIZE %x\r\n", __FUNCTION__, SIZE));
+  DEBUG ((DEBUG_VERBOSE, "%a: SIZE %x\r\n", __FUNCTION__, SIZE));
   Value  = 0;
   Value |= ((SIZE & 0xfff)) << 8;
   FalconWrite32 (XUSB_CSB_MEMPOOL_ILOAD_ATTR_0, Value);
   SRC_ADDR = (FirmwareAddress >> 0) & 0xffffffff;
-  DEBUG ((EFI_D_VERBOSE, "%a: SRC_ADDR %x\r\n", __FUNCTION__, SRC_ADDR));
+  DEBUG ((DEBUG_VERBOSE, "%a: SRC_ADDR %x\r\n", __FUNCTION__, SRC_ADDR));
   Value  = 0;
   Value |= ((SRC_ADDR & /*0xff*/ 0xffffffff)) << 0;
   FalconWrite32 (XUSB_CSB_MEMPOOL_ILOAD_BASE_LO_0, Value);
   SRC_ADDR = (FirmwareAddress >> 32) & 0xffffffff;
-  DEBUG ((EFI_D_VERBOSE, "%a: SRC_ADDR %x\r\n", __FUNCTION__, SRC_ADDR));
+  DEBUG ((DEBUG_VERBOSE, "%a: SRC_ADDR %x\r\n", __FUNCTION__, SRC_ADDR));
   Value  = 0;
   Value |= ((SRC_ADDR & /*0xff*/ 0xffffffff)) << 0;
   FalconWrite32 (XUSB_CSB_MEMPOOL_ILOAD_BASE_HI_0, Value);
 
   /* set BOOTPATH to 1 in APMAP */
   BOOTPATH = 1;
-  DEBUG ((EFI_D_VERBOSE, "%a: BOOTPATH %x\r\n", __FUNCTION__, BOOTPATH));
+  DEBUG ((DEBUG_VERBOSE, "%a: BOOTPATH %x\r\n", __FUNCTION__, BOOTPATH));
   Value  = 0;
   Value  = FalconRead32 (XUSB_CSB_MEMPOOL_APMAP_0);
   Value |= ((BOOTPATH & 0x1)) << 31;
@@ -373,9 +373,9 @@ FalconFirmwareLoad (
 
   /* invalidate L2IMEM entries */
   ACTION = 0x40 /* L2IMEM_INVALIDATE_ALL */;
-  DEBUG ((EFI_D_VERBOSE, "%a: ACTION %x\r\n", __FUNCTION__, ACTION));
+  DEBUG ((DEBUG_VERBOSE, "%a: ACTION %x\r\n", __FUNCTION__, ACTION));
   DEST_INDEX = 0;
-  DEBUG ((EFI_D_VERBOSE, "%a: DEST_INDEX %x\r\n", __FUNCTION__, DEST_INDEX));
+  DEBUG ((DEBUG_VERBOSE, "%a: DEST_INDEX %x\r\n", __FUNCTION__, DEST_INDEX));
   Value  = 0;
   Value |= (ACTION & 0xff) << 24;
   Value |= (DEST_INDEX & 0x3ff) << 8;
@@ -383,17 +383,17 @@ FalconFirmwareLoad (
 
   /* fetch complete bootstrap into L2IMEM */
   SRC_OFFSET = (FirmwareCfg->boot_codetag + (IMEM_BLOCK_SIZE - 1)) / IMEM_BLOCK_SIZE;
-  DEBUG ((EFI_D_VERBOSE, "%a: SRC_OFFSET %x\r\n", __FUNCTION__, SRC_OFFSET));
+  DEBUG ((DEBUG_VERBOSE, "%a: SRC_OFFSET %x\r\n", __FUNCTION__, SRC_OFFSET));
   SRC_COUNT = (FirmwareCfg->boot_codesize + (IMEM_BLOCK_SIZE - 1)) / IMEM_BLOCK_SIZE;
-  DEBUG ((EFI_D_VERBOSE, "%a: SRC_COUNT %x\r\n", __FUNCTION__, SRC_COUNT));
+  DEBUG ((DEBUG_VERBOSE, "%a: SRC_COUNT %x\r\n", __FUNCTION__, SRC_COUNT));
   Value  = 0;
   Value |= ((SRC_OFFSET & 0xfff)) << 8;
   Value |= ((SRC_COUNT & 0xff)) << 24;
   FalconWrite32 (XUSB_CSB_MEMPOOL_L2IMEMOP_SIZE_0, Value);
   ACTION = 0x11 /* L2IMEM_LOAD_LOCKED_RESULT */;
-  DEBUG ((EFI_D_VERBOSE, "%a: ACTION %x\r\n", __FUNCTION__, ACTION));
+  DEBUG ((DEBUG_VERBOSE, "%a: ACTION %x\r\n", __FUNCTION__, ACTION));
   DEST_INDEX = 0;
-  DEBUG ((EFI_D_VERBOSE, "%a: DEST_INDEX %x\r\n", __FUNCTION__, DEST_INDEX));
+  DEBUG ((DEBUG_VERBOSE, "%a: DEST_INDEX %x\r\n", __FUNCTION__, DEST_INDEX));
   Value  = 0;
   Value |= (ACTION & 0xff) << 24;
   Value |= (DEST_INDEX & 0x3ff) << 8;
@@ -401,16 +401,16 @@ FalconFirmwareLoad (
 
   /* reserve required IMEM blocks by writing to IMEMFILLCTL register */
   NBLOCKS = SRC_COUNT;
-  DEBUG ((EFI_D_VERBOSE, "%a: NBLOCKS %x\r\n", __FUNCTION__, NBLOCKS));
+  DEBUG ((DEBUG_VERBOSE, "%a: NBLOCKS %x\r\n", __FUNCTION__, NBLOCKS));
   Value  = 0;
   Value |= ((NBLOCKS & 0xff)) << 0;
   FalconWrite32 (FALCON_IMFILLCTL_0, Value);
 
   /* enable auto-fill mode for bootstrap code range */
   TAG_LO = (SRC_OFFSET & 0xffff);
-  DEBUG ((EFI_D_VERBOSE, "%a: TAG_LO %x\r\n", __FUNCTION__, TAG_LO));
+  DEBUG ((DEBUG_VERBOSE, "%a: TAG_LO %x\r\n", __FUNCTION__, TAG_LO));
   TAG_HI = ((SRC_OFFSET + SRC_COUNT) & 0xffff);
-  DEBUG ((EFI_D_VERBOSE, "%a: TAG_HI %x\r\n", __FUNCTION__, TAG_HI));
+  DEBUG ((DEBUG_VERBOSE, "%a: TAG_HI %x\r\n", __FUNCTION__, TAG_HI));
   Value  = 0;
   Value |= ((TAG_HI & 0xffff)) << 16;
   Value |= ((TAG_LO & 0xffff)) << 0;
@@ -423,7 +423,7 @@ FalconFirmwareLoad (
   /* wait for RESULT_VLD to get set */
   for (i = 0; i < 100; i++) {
     Value = FalconRead32 (XUSB_CSB_MEMPOOL_L2IMEMOP_RESULT_0);
-    DEBUG ((EFI_D_VERBOSE, "%a: XUSB_CSB_MEMPOOL_L2IMEMOP_RESULT_0 = %x\r\n", __FUNCTION__, Value));
+    DEBUG ((DEBUG_VERBOSE, "%a: XUSB_CSB_MEMPOOL_L2IMEMOP_RESULT_0 = %x\r\n", __FUNCTION__, Value));
     if (Value & L2IMEMOP_RESULT_VLD) {
       break;
     }
@@ -433,7 +433,7 @@ FalconFirmwareLoad (
 
   /* program BOOTVEC with Falcon boot code location in IMEM */
   VEC = FirmwareCfg->boot_codetag;
-  DEBUG ((EFI_D_VERBOSE, "%a: VEC %x\r\n", __FUNCTION__, VEC));
+  DEBUG ((DEBUG_VERBOSE, "%a: VEC %x\r\n", __FUNCTION__, VEC));
   Value  = 0;
   Value |= ((VEC & 0xffffffff)) << 0;
   FalconWrite32 (FALCON_BOOTVEC_0, Value);
@@ -448,13 +448,13 @@ FalconFirmwareLoad (
 
   for (i = 0; i < 10; i++) {
     Value = FalconRead32 (FALCON_CPUCTL_0);
-    DEBUG ((EFI_D_VERBOSE, "%a: FALCON_CPUCTL_0 = %x\r\n", __FUNCTION__, Value));
+    DEBUG ((DEBUG_VERBOSE, "%a: FALCON_CPUCTL_0 = %x\r\n", __FUNCTION__, Value));
     if (Value & 0x20 /* stopped */) {
       break;
     }
   }
 
-  DEBUG ((EFI_D_VERBOSE, "%a: FALCON_CPUCTL_0 = %x\r\n", __FUNCTION__, Value));
+  DEBUG ((DEBUG_VERBOSE, "%a: FALCON_CPUCTL_0 = %x\r\n", __FUNCTION__, Value));
 
   /* dump DMEM */
   FalconDumpDMEM ();

--- a/Silicon/NVIDIA/PrePi/PrePi.c
+++ b/Silicon/NVIDIA/PrePi/PrePi.c
@@ -42,7 +42,7 @@ InitMmu (
   //      DRAM (even at the top of DRAM as it is the first permanent memory allocation)
   Status = ArmConfigureMmu (MemoryTable, &TranslationTableBase, &TranslationTableSize);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "Error: Failed to enable MMU\n"));
+    DEBUG ((DEBUG_ERROR, "Error: Failed to enable MMU\n"));
   }
 }
 
@@ -173,7 +173,7 @@ DisplayHobResource (
         ((UINTN)HobBase < NextHob.ResourceDescriptor->PhysicalStart + NextHob.ResourceDescriptor->ResourceLength))
     {
       DEBUG ((
-        EFI_D_INIT,
+        DEBUG_INIT,
         "Main memory region: (0x%016llx, 0x%016llx)\r\n",
         NextHob.ResourceDescriptor->PhysicalStart,
         NextHob.ResourceDescriptor->ResourceLength
@@ -214,7 +214,7 @@ PrintModel (
       return;
     }
 
-    DEBUG ((EFI_D_ERROR, "Model: %a\n", Data));
+    DEBUG ((DEBUG_ERROR, "Model: %a\n", Data));
   }
 }
 

--- a/Silicon/NVIDIA/PrePi/PrePiMemory.c
+++ b/Silicon/NVIDIA/PrePi/PrePiMemory.c
@@ -68,7 +68,7 @@ GetVirtualMemoryMap (
   while (NULL != HobList) {
     EFI_HOB_RESOURCE_DESCRIPTOR  *Resource = (EFI_HOB_RESOURCE_DESCRIPTOR *)HobList;
     DEBUG ((
-      EFI_D_VERBOSE,
+      DEBUG_VERBOSE,
       "ArmPlatformGetVirtualMemoryMap() Resource: Base: 0x%016lx, Size: 0x%016lx, Type: 0x%x\n",
       Resource->PhysicalStart,
       Resource->ResourceLength,

--- a/Silicon/NVIDIA/Tegra/T194/Drivers/SeRngDxe/SeRngDxe.c
+++ b/Silicon/NVIDIA/Tegra/T194/Drivers/SeRngDxe/SeRngDxe.c
@@ -279,14 +279,14 @@ DeviceDiscoveryNotify (
       Private = (SE_RNG_PRIVATE_DATA *)AllocateZeroPool (sizeof (SE_RNG_PRIVATE_DATA));
       if (Private == NULL) {
         Status = EFI_OUT_OF_RESOURCES;
-        DEBUG ((EFI_D_ERROR, "SeRngDxe: Failed to allocate private data structure\r\n"));
+        DEBUG ((DEBUG_ERROR, "SeRngDxe: Failed to allocate private data structure\r\n"));
         break;
       }
 
       Private->Signature = SE_RNG_SIGNATURE;
       Status             = DeviceDiscoveryGetMmioRegion (ControllerHandle, 1, &Private->BaseAddress, &RegionSize);
       if (EFI_ERROR (Status)) {
-        DEBUG ((EFI_D_ERROR, "SeRngDxe: Failed to get region location (%r)\r\n", Status));
+        DEBUG ((DEBUG_ERROR, "SeRngDxe: Failed to get region location (%r)\r\n", Status));
         FreePool (Private);
         break;
       }
@@ -302,7 +302,7 @@ DeviceDiscoveryNotify (
                       NULL
                       );
       if (EFI_ERROR (Status)) {
-        DEBUG ((EFI_D_ERROR, "SeRngDxe: Failed to install protocol (%r)\r\n", Status));
+        DEBUG ((DEBUG_ERROR, "SeRngDxe: Failed to install protocol (%r)\r\n", Status));
         FreePool (Private);
         break;
       }
@@ -312,7 +312,7 @@ DeviceDiscoveryNotify (
     case DeviceDiscoveryDriverBindingStop:
       Status = gBS->HandleProtocol (ControllerHandle, &gEfiCallerIdGuid, (VOID **)&Private);
       if (EFI_ERROR (Status)) {
-        DEBUG ((EFI_D_ERROR, "SeRng: Failed to get private data (%r)\r\n", Status));
+        DEBUG ((DEBUG_ERROR, "SeRng: Failed to get private data (%r)\r\n", Status));
         break;
       }
 
@@ -325,7 +325,7 @@ DeviceDiscoveryNotify (
                       NULL
                       );
       if (EFI_ERROR (Status)) {
-        DEBUG ((EFI_D_ERROR, "SeRng: Failed to uninstall procotol (%r)\r\n", Status));
+        DEBUG ((DEBUG_ERROR, "SeRng: Failed to uninstall procotol (%r)\r\n", Status));
         break;
       }
 

--- a/Silicon/NVIDIA/Tegra/T234/Drivers/SeRngDxe/SeRngDxe.c
+++ b/Silicon/NVIDIA/Tegra/T234/Drivers/SeRngDxe/SeRngDxe.c
@@ -98,7 +98,7 @@ SeRngGetRandom128 (
   } while ((MaxPollCount > 0) && (AesStatus != 0));
 
   if (AesStatus != 0) {
-    DEBUG ((EFI_D_ERROR, "%a, Timeout waiting for random\r\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a, Timeout waiting for random\r\n", __FUNCTION__));
     Status = EFI_DEVICE_ERROR;
     goto ErrorExit;
   }
@@ -155,14 +155,14 @@ DeviceDiscoveryNotify (
       Private = (SE_RNG_PRIVATE_DATA *)AllocateZeroPool (sizeof (SE_RNG_PRIVATE_DATA));
       if (Private == NULL) {
         Status = EFI_OUT_OF_RESOURCES;
-        DEBUG ((EFI_D_ERROR, "SeRngDxe: Failed to allocate private data structure\r\n"));
+        DEBUG ((DEBUG_ERROR, "SeRngDxe: Failed to allocate private data structure\r\n"));
         break;
       }
 
       Private->Signature = SE_RNG_SIGNATURE;
       Status             = DeviceDiscoveryGetMmioRegion (ControllerHandle, 0, &Private->BaseAddress, &RegionSize);
       if (EFI_ERROR (Status)) {
-        DEBUG ((EFI_D_ERROR, "SeRngDxe: Failed to get region location (%r)\r\n", Status));
+        DEBUG ((DEBUG_ERROR, "SeRngDxe: Failed to get region location (%r)\r\n", Status));
         FreePool (Private);
         break;
       }
@@ -178,7 +178,7 @@ DeviceDiscoveryNotify (
                       NULL
                       );
       if (EFI_ERROR (Status)) {
-        DEBUG ((EFI_D_ERROR, "SeRngDxe: Failed to install protocol (%r)\r\n", Status));
+        DEBUG ((DEBUG_ERROR, "SeRngDxe: Failed to install protocol (%r)\r\n", Status));
         FreePool (Private);
         break;
       }
@@ -188,7 +188,7 @@ DeviceDiscoveryNotify (
     case DeviceDiscoveryDriverBindingStop:
       Status = gBS->HandleProtocol (ControllerHandle, &gEfiCallerIdGuid, (VOID **)&Private);
       if (EFI_ERROR (Status)) {
-        DEBUG ((EFI_D_ERROR, "SeRng: Failed to get private data (%r)\r\n", Status));
+        DEBUG ((DEBUG_ERROR, "SeRng: Failed to get private data (%r)\r\n", Status));
         break;
       }
 
@@ -201,7 +201,7 @@ DeviceDiscoveryNotify (
                       NULL
                       );
       if (EFI_ERROR (Status)) {
-        DEBUG ((EFI_D_ERROR, "SeRng: Failed to uninstall procotol (%r)\r\n", Status));
+        DEBUG ((DEBUG_ERROR, "SeRng: Failed to uninstall procotol (%r)\r\n", Status));
         break;
       }
 


### PR DESCRIPTION
EFI_D_* is deprecated, so use DEBUG_* instead.

Signed-off-by: Rebecca Cran <rebecca@bsdio.com>