### PR TITLE
fix: ensure termination of TnSpec variables

### DIFF
--- a/Silicon/NVIDIA/Library/FmpDeviceLib/TegraFmp.c
+++ b/Silicon/NVIDIA/Library/FmpDeviceLib/TegraFmp.c
@@ -169,7 +169,8 @@ GetFuseSettings (
     return EFI_SUCCESS;
   }
 
-  mPlatformSpec = (CHAR8 *)AllocateRuntimeZeroPool (Size);
+  // Add 1 for null termination so this pointer can be used with string functions
+  mPlatformSpec = (CHAR8 *)AllocateRuntimeZeroPool (Size+1);
   if (mPlatformSpec == NULL) {
     DEBUG ((DEBUG_ERROR, "%a: Spec alloc failed\n", __FUNCTION__));
     return EFI_OUT_OF_RESOURCES;
@@ -262,7 +263,8 @@ GetTnSpec (
     goto UseDefault;
   }
 
-  mPlatformCompatSpec = (CHAR8 *)AllocateRuntimeZeroPool (Size);
+  // Add 1 for null termination so this pointer can be used with string functions
+  mPlatformCompatSpec = (CHAR8 *)AllocateRuntimeZeroPool (Size+1);
   if (mPlatformCompatSpec == NULL) {
     DEBUG ((DEBUG_ERROR, "%a: CompatSpec alloc failed\n", __FUNCTION__));
     return EFI_OUT_OF_RESOURCES;


### PR DESCRIPTION
[GetTnSpec](https://github.com/NVIDIA/edk2-nvidia/blob/8d42d1cfd61af8a9ef7f136366a1885887e4a7cd/Silicon/NVIDIA/Library/FmpDeviceLib/TegraFmp.c#L239) [allocates memory for mPlatformCompatSpec](https://github.com/NVIDIA/edk2-nvidia/blob/8d42d1cfd61af8a9ef7f136366a1885887e4a7cd/Silicon/NVIDIA/Library/FmpDeviceLib/TegraFmp.c#L265) based on the [size returned by GetVariable](https://github.com/NVIDIA/edk2-nvidia/blob/8d42d1cfd61af8a9ef7f136366a1885887e4a7cd/Silicon/NVIDIA/Library/FmpDeviceLib/TegraFmp.c#L247) which is ultimately [provided to FwPackageGetImageIndex](https://github.com/NVIDIA/edk2-nvidia/blob/8d42d1cfd61af8a9ef7f136366a1885887e4a7cd/Silicon/NVIDIA/Library/FmpDeviceLib/TegraFmp.c#L593) and [passed to FwPackageCheckTnSpec](https://github.com/NVIDIA/edk2-nvidia/blob/8d42d1cfd61af8a9ef7f136366a1885887e4a7cd/Silicon/NVIDIA/Library/FwPackageLib/FwPackageLib.c#L236).  The FwPackageCheckTnSpec  function [assumes the values are null terminated strings](https://github.com/NVIDIA/edk2-nvidia/blob/8d42d1cfd61af8a9ef7f136366a1885887e4a7cd/Silicon/NVIDIA/Library/FwPackageLib/FwPackageLib.c#L133) when in fact they are not stored this way in practice (when running with Stock Jetpack or OE4T, see example variable content [here](https://matrix.to/#/!YBfWVpJwNVtkmqVCPS:gitter.im/$0poxR3SlvbW5XWtKBLm7Rps7pbTAaxYA6KhhqgbVk00?via=gitter.im&via=matrix.org&via=3dvisionlabs.com)).

There may be other cases where null termination should be added to values returned by GetVariable, and this likely needs further review.  This fix addresses only CompatSpec and FullSpec variables which are necessary for supporting [Capsule Updates](https://docs.nvidia.com/jetson/archives/r35.3.1/DeveloperGuide/text/SD/Bootloader/UpdateAndRedundancy.html#generating-the-capsule-update-payload) on OE4T Jetpack 5.x.