### PR TITLE
fix: ensure termination of TnSpec variables

### DIFF
--- a/Silicon/NVIDIA/Library/FmpDeviceLib/TegraFmp.c
+++ b/Silicon/NVIDIA/Library/FmpDeviceLib/TegraFmp.c
@@ -169,7 +169,8 @@ GetFuseSettings (
     return EFI_SUCCESS;
   }
 
-  mPlatformSpec = (CHAR8 *)AllocateRuntimeZeroPool (Size);
+  // ensure null termination
+  mPlatformSpec = (CHAR8 *)AllocateRuntimeZeroPool (Size + 1);
   if (mPlatformSpec == NULL) {
     DEBUG ((DEBUG_ERROR, "%a: Spec alloc failed\n", __FUNCTION__));
     return EFI_OUT_OF_RESOURCES;
@@ -262,7 +263,8 @@ GetTnSpec (
     goto UseDefault;
   }
 
-  mPlatformCompatSpec = (CHAR8 *)AllocateRuntimeZeroPool (Size);
+  // ensure null termination
+  mPlatformCompatSpec = (CHAR8 *)AllocateRuntimeZeroPool (Size + 1);
   if (mPlatformCompatSpec == NULL) {
     DEBUG ((DEBUG_ERROR, "%a: CompatSpec alloc failed\n", __FUNCTION__));
     return EFI_OUT_OF_RESOURCES;


### PR DESCRIPTION
Ensure strings read from UEFI variables TegraPlatformSpec and TegraPlatformCompatSpec are null-terminated before using them.


Tested-by: Ashish Singhal <ashishsingha@nvidia.com>
Reviewed-by: Ashish Singhal <ashishsingha@nvidia.com>