### PR TITLE
fix: Boot Menu console option settings

### DIFF
--- a/Platform/NVIDIA/NVIDIA.common.dsc.inc
+++ b/Platform/NVIDIA/NVIDIA.common.dsc.inc
@@ -635,6 +635,7 @@
   gNVIDIATokenSpaceGuid.PcdPcieEntryInAcpi|L"EnablePcieInOS"|gNVIDIATokenSpaceGuid|0x0|0|BS,NV
   gNVIDIATokenSpaceGuid.PcdSerialTypeConfig|L"SerialTypeConfig"|gNVIDIATokenSpaceGuid|0x0|0xFF|BS
   gNVIDIATokenSpaceGuid.PcdSerialPortConfig|L"SerialPortConfig"|gNVIDIATokenSpaceGuid|0x0|0xFF|BS,NV
+  gNVIDIATokenSpaceGuid.PcdDoInitialConsoleRegistration|L"DoInitialConsoleRegistration"|gNVIDIAPublicVariableGuid|0x0|1|BS,NV
   # NVIDIA Public variables
   gNVIDIATokenSpaceGuid.PcdQuickBootEnabled|L"QuickBootEnabled"|gNVIDIAPublicVariableGuid|0x0|1|BS,NV
   gNVIDIATokenSpaceGuid.PcdNewDeviceHierarchy|L"NewDeviceHierarchy"|gNVIDIAPublicVariableGuid|0x0|0|BS,NV

--- a/Silicon/NVIDIA/Library/PlatformBootManagerLib/PlatformBootManagerLib.inf
+++ b/Silicon/NVIDIA/Library/PlatformBootManagerLib/PlatformBootManagerLib.inf
@@ -1,7 +1,7 @@
 ## @file
 #  Implementation for PlatformBootManagerLib library class interfaces.
 #
-#  Copyright (c) 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#  Copyright (c) 2020-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #  Copyright (C) 2015-2016, Red Hat, Inc.
 #  Copyright (c) 2014, ARM Ltd. All rights reserved.<BR>
 #  Copyright (c) 2007 - 2014, Intel Corporation. All rights reserved.<BR>
@@ -79,6 +79,7 @@
   gNVIDIATokenSpaceGuid.PcdQuickBootEnabled
   gNVIDIATokenSpaceGuid.PcdBootMenuAppFile
   gNVIDIATokenSpaceGuid.PcdBootManagerWaitMessage
+  gNVIDIATokenSpaceGuid.PcdDoInitialConsoleRegistration
 
 [Guids]
   gEfiFileInfoGuid

--- a/Silicon/NVIDIA/NVIDIA.dec
+++ b/Silicon/NVIDIA/NVIDIA.dec
@@ -494,3 +494,6 @@
 
 #Option to enable/disable EFI FB for dGPU
   gNVIDIATokenSpaceGuid.PcdDgpuDtEfifbSupport|0x00|UINT8|0x0000009C
+
+#Indicate whether initial console device registration should be done.
+  gNVIDIATokenSpaceGuid.PcdDoInitialConsoleRegistration|TRUE|BOOLEAN|0x0000010A


### PR DESCRIPTION
Change PlatformRegisterConsoles() to only call
EfiBootManagerUpdateConsoleVariable() for [ConOut|ErrOut|ConIn] on the first boot, instead of re-initializing those persistent variables on every boot. This is controlled by a new Boolean PCD PcdDoInitialConsoleRegistration.

This fixes Boot Menu console settings not persisting through reboots.

Fixes #38 

Signed-off-by: Aron Wong <awong@nvidia.com>
Reviewed-by: Ashish Singhal <ashishsingha@nvidia.com>
Tested-by: Ashish Singhal <ashishsingha@nvidia.com>