### PR TITLE
fix: update max capsule size supported

### DIFF
--- a/Platform/NVIDIA/Jetson/Jetson.dsc.inc
+++ b/Platform/NVIDIA/Jetson/Jetson.dsc.inc
@@ -55,6 +55,7 @@
   gFmpDevicePkgTokenSpaceGuid.PcdFmpDeviceImageTypeIdGuid|{GUID("$(SYSTEM_FMP_ESRT_GUID)")}
   gEfiMdeModulePkgTokenSpaceGuid.PcdCapsuleOnDiskSupport|TRUE
   gEfiMdeModulePkgTokenSpaceGuid.PcdCapsuleInRamSupport|TRUE
+  gEfiMdeModulePkgTokenSpaceGuid.PcdMaxSizeNonPopulateCapsule|0xc00000
 
 [PcdsDynamicDefault.common]
   # Console Resolution


### PR DESCRIPTION
Update maximum capsule size reported by the
QueryCapsuleCapabilities UEFI RT service and
used by CapsuleApp.


Tested-by: Ashish Singhal <ashishsingha@nvidia.com>
Reviewed-by: Ashish Singhal <ashishsingha@nvidia.com>