### PR TITLE
fix(github): Migrate to NVIDIA-Platforms

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,7 @@
+prerelease: true
+template: |
+  ## What’s Changed
+
+  ## Details
+
+  $CHANGES

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,10 +6,12 @@
 
 name: Build and release
 on:
+  pull_request: {}
   push:
     branches:
       - 'main'
-      - 'main.*'
+      - 'r*updates'
+    tags:
       - 'r*'
 env:
   EDKREPO_URL: https://github.com/tianocore/edk2-edkrepo/releases/download/edkrepo-v2.1.2/edkrepo-2.1.2.tar.gz
@@ -55,8 +57,13 @@ jobs:
         run: |
           set -x
           cd ${{ github.workspace }}
+          # Derive the edkrepo combo.  We'll assume it matches the branch name.
+          EDKREPO_COMBO=${{ github.head_ref	}}
+          if [[ ${{ github.event_name }} = pull_request ]]; then
+            EDKREPO_COMBO=${{ github.base_ref	}}
+          fi
           # Start with the edkrepo combo that matches this branch
-          edkrepo clone -v workspace NVIDIA-Jetson ${GITHUB_REF_NAME%.*}
+          edkrepo clone -v workspace NVIDIA-Platforms ${EDKREPO_COMBO}
           cd workspace
           # Checkout the ref that triggered this build
           git -C edk2-nvidia fetch --verbose "${{ github.server_url }}/${{ github.repository }}" "${{ github.ref }}"
@@ -105,11 +112,10 @@ jobs:
           name: package
           path: upload
       - name: Release
-        uses: ncipollo/release-action@v1.10.0
-        with:
-          draft: true
-          prerelease: true
-          name: edk2-nvidia-${{ steps.package.outputs.version }}
-          tag: ${{ github.ref_name }}-${{ steps.package.outputs.version }}
-          commit: ${{ github.sha }}
-          artifacts: edk2-nvidia-${{ steps.package.outputs.version }}.tar.gz
+        if: github.event_name != 'pull_request'
+        uses: release-drafter/release-drafter@v5
+        env:
+          VERSION: ${{ steps.package.outputs.version }}
+          REF_NAME: ${{ github.ref_name }}
+          SHA: ${{ github.sha }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Follow the edkrepo manifest from NVIDIA-Jetson to NVIDIA-Platforms. Also, fix the workflow for pull requests.

Signed-off-by: Jake Garver <jake@nvidia.com>