### PR TITLE
Fix error with no serial ports configured on T194

### DIFF
--- a/Silicon/NVIDIA/Tegra/T194/Drivers/ConfigurationManager/ConfigurationManagerData/ConfigurationManagerDataDxe.c
+++ b/Silicon/NVIDIA/Tegra/T194/Drivers/ConfigurationManager/ConfigurationManagerData/ConfigurationManagerDataDxe.c
@@ -424,8 +424,8 @@ UpdateSerialPortInfo (
   }
 
   if (*Map == NULL) {
-    DEBUG ((DEBUG_ERROR, "%a: No Matches found \n", __FUNCTION__));
-    return Status;
+    // Do not treat no serial ports as an error
+    return EFI_SUCCESS;
   }
 
   SerialHandles = (UINT32 *)AllocatePool (sizeof (UINT32) * NumberOfSerialPorts);


### PR DESCRIPTION
The behavior of `UpdateSerialPortInfo` for the T234 differs from that of the T194. When all serial ports are disabled on the T234, DSDT is not patched with serial port info and the ConfigurationManager DXE resumes as normal. When this is the case on the T194, the error bubbles up to the top of ConfigurationManager's entrypoint, causing many further configuration tables to not be populated (SMBIOS being one of them).