### PR TITLE
fix(eqos): Use correct TX clock name

### DIFF
--- a/Silicon/NVIDIA/Drivers/EqosDeviceDxe/PhyDxeUtil.c
+++ b/Silicon/NVIDIA/Drivers/EqosDeviceDxe/PhyDxeUtil.c
@@ -391,7 +391,7 @@ PhyLinkAdjustEmacConfig (
         osi_set_mode (PhyDriver->MacDriver->osi_core, OSI_HALF_DUPLEX);
       }
 
-      Status = DeviceDiscoverySetClockFreq (PhyDriver->ControllerHandle, "tx", ClockRate);
+      Status = DeviceDiscoverySetClockFreq (PhyDriver->ControllerHandle, "eqos_tx", ClockRate);
       if (EFI_ERROR (Status)) {
         DEBUG ((EFI_D_ERROR, "%a, Failed to set clock frequency %r\r\n", __FUNCTION__, Status));
         Status = EFI_SUCCESS;


### PR DESCRIPTION
EqosDeviceDxe would fail to set the TX clock rate with the following output:
```
PhyLinkAdjustEmacConfig: Failed to set clock frequency Not Found
```
This prevented the network from working at 100Base-T or 10Base-T. (Tested on Xavier NX devkit). The clock name used in the device tree from NVIDIA's sources is "eqos_tx".

Signed-off-by: Daniel Fullmer <dfullmer@anduril.com>