### PR TITLE
fix: Disable outline-atomics for nvethernetrm

### DIFF
--- a/Silicon/NVIDIA/Drivers/EqosDeviceDxe/EqosDeviceDxe.inf
+++ b/Silicon/NVIDIA/Drivers/EqosDeviceDxe/EqosDeviceDxe.inf
@@ -110,4 +110,7 @@
 
 [BuildOptions]
   *_*_*_PP_FLAGS = -DUPDATED_PAD_CAL -DMACSEC_SUPPORT
-  *_*_*_CC_FLAGS = -DUPDATED_PAD_CAL -DMACSEC_SUPPORT -Wno-unused-function -Wno-self-assign
+  # -mno-outline-atomics is required for GCC 10.x and later, which makes
+  # -moutline-atomics the default.  nvethernetrm uses atomics not currently
+  # supported by CompilerIntrinsicsLib.
+  *_*_*_CC_FLAGS = -DUPDATED_PAD_CAL -DMACSEC_SUPPORT -Wno-unused-function -Wno-self-assign -mno-outline-atomics


### PR DESCRIPTION
This fixes a compile issue on versions of GCC 10.x or later that enable outline-atomics by default.  CompilerIntrinsicsLib supports many of these atomics, but not the ones in use by nvethernetrm.

Signed-off-by: Jake Garver <jake@nvidia.com>
Reviewed-by: Jeff Brasen <jbrasen@nvidia.com>