### PR TITLE
fix(github): Correct branch builds in workflow, take 2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,7 @@ jobs:
           set -x
           cd ${{ github.workspace }}
           # Derive the edkrepo combo.  We'll assume it matches the branch name.
-          EDKREPO_COMBO=${{ github.ref }}
+          EDKREPO_COMBO=${{ github.ref_name }}
           if [[ ${{ github.event_name }} = pull_request ]]; then
             EDKREPO_COMBO=${{ github.base_ref	}}
           fi


### PR DESCRIPTION
The github.head_ref is only defined for pull requests.  We should be using github.ref_name instead.

github.head_ref was working for some branches because it became an empty string.  That led to the default combo being used, which is "main".