### PR TITLE
chore: allow extra characters for command line

### DIFF
--- a/Platform/NVIDIA/Jetson/Jetson.dsc.inc
+++ b/Platform/NVIDIA/Jetson/Jetson.dsc.inc
@@ -141,6 +141,7 @@
   gNVIDIATokenSpaceGuid.PcdFramebufferBarIndex|1
   gNVIDIATokenSpaceGuid.PcdL4TConfigurationSupport|TRUE
   gNVIDIATokenSpaceGuid.PcdFtpmShmSize|4096
+  gEmbeddedTokenSpaceGuid.PcdAndroidKernelCommandLineOverflow|100
 
 ################################################################################
 #


### PR DESCRIPTION
set pcd to tell about extra kernel command line parameters expected on jetson platforms for android style boot.