### PR TITLE
chore: allow extra characters for command line

### DIFF
--- a/Platform/NVIDIA/Jetson/Jetson.dsc.inc
+++ b/Platform/NVIDIA/Jetson/Jetson.dsc.inc
@@ -144,6 +144,7 @@
   gEfiMdeModulePkgTokenSpaceGuid.PcdFirmwareVersionString|L"$(BUILDID_STRING)"
   gEfiMdeModulePkgTokenSpaceGuid.PcdFirmwareReleaseDateString|L"$(BUILD_DATE_TIME)"
   gNVIDIATokenSpaceGuid.PcdFtpmShmSize|4096
+  gEmbeddedTokenSpaceGuid.PcdAndroidKernelCommandLineOverflow|100
 
 ################################################################################
 #


### PR DESCRIPTION
set pcd to tell about extra kernel command line parameters expected on jetson platforms for android style boot.