### PR TITLE
feat: Disable watchdog with extra debug

### DIFF
--- a/Platform/NVIDIA/Kconfig
+++ b/Platform/NVIDIA/Kconfig
@@ -625,7 +625,9 @@ menu  "Watchdog settings"
   int  "Boot watchdog timeout"
   default  5
   help
-    Time in minutes to reboot system before boot options are processed
+    Time in minutes to reboot system before boot options are processed.
+    This may be customized based on changes in the boot.
+    For example changing the debug print level may impact boot time.
 
   config  ARM_WATCHDOG
     bool "Use ARM watchdog instead of timer"

--- a/Platform/NVIDIA/NVIDIA.common.dsc.inc
+++ b/Platform/NVIDIA/NVIDIA.common.dsc.inc
@@ -701,6 +701,8 @@ CONFIG_ARM_WATCHDOG_INTERRUPT=0
   #  DEBUG_VERBOSE   0x00400000  // Detailed debug messages that may
   #                              // significantly impact boot performance
   #  DEBUG_ERROR     0x80000000  // Error
+  #
+  #  If this is changed the boot watchdog value should be reevaluated.
   gEfiMdePkgTokenSpaceGuid.PcdDebugPrintErrorLevel|0x8000000F
 
   gNVIDIATokenSpaceGuid.PcdAssertResetTimeoutValue|5

--- a/Silicon/NVIDIA/Drivers/BootWatchdog/BootWatchdog.c
+++ b/Silicon/NVIDIA/Drivers/BootWatchdog/BootWatchdog.c
@@ -1,13 +1,14 @@
 /** @file
   This driver registers a 5 minute watchdog between when it starts and ReadyToBoot.
 
-  SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-FileCopyrightText: Copyright (c) 2023-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
 
 #include <PiDxe.h>
 #include <Library/DebugLib.h>
+#include <Library/DebugPrintErrorLevelLib.h>
 #include <Library/DtPlatformDtbLoaderLib.h>
 #include <Library/UefiBootServicesTableLib.h>
 #include <Library/UefiLib.h>
@@ -54,6 +55,11 @@ WatchDogTimerReady (
 
   if (WatchdogTimout == MAX_UINT32) {
     WatchdogTimout = PcdGet16 (PcdBootWatchdogTime) * 60;
+  }
+
+  if ((GetDebugPrintErrorLevel () & ~PcdGet32 (PcdDebugPrintErrorLevel)) != 0) {
+    DEBUG ((DEBUG_ERROR, "%a: watchdog disabled as extra debug is enabled\r\n", __FUNCTION__));
+    WatchdogTimout = 0;
   }
 
   Status = gBS->SetWatchdogTimer (WatchdogTimout, 0x0001, 0, NULL);

--- a/Silicon/NVIDIA/Drivers/BootWatchdog/BootWatchdog.inf
+++ b/Silicon/NVIDIA/Drivers/BootWatchdog/BootWatchdog.inf
@@ -1,7 +1,7 @@
 ## @file
 #  This driver registers a 5 minute watchdog between when it starts and ReadyToBoot.
 #
-#  SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#  SPDX-FileCopyrightText: Copyright (c) 2023-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
@@ -27,6 +27,7 @@
   UefiBootServicesTableLib
   UefiDriverEntryPoint
   DebugLib
+  DebugPrintErrorLevelLib
   DtPlatformDtbLoaderLib
   DxeServicesLib
   FdtLib
@@ -35,6 +36,7 @@
 
 [Pcd]
   gNVIDIATokenSpaceGuid.PcdBootWatchdogTime
+  gEfiMdePkgTokenSpaceGuid.PcdDebugPrintErrorLevel  ## CONSUMES
 
 [Protocols]
   gEfiWatchdogTimerArchProtocolGuid


### PR DESCRIPTION
If extra debug is being enabled then the watchdog should be disabled. Boot may take longer than build time configuration. User is likely debugging so a watchdog is likely not desired

Jira TEGRAUEFI-3543
Bug 4568667

Change-Id: Ia3ab5dca61763a4aa32901baf70030fc9a2cf1ec

Reviewed-on: https://git-master.nvidia.com/r/c/tegra/bootloader/uefi/edk2-nvidia/+/3110405
Reviewed-by: mobile promotions <svcmobile_promotions@nvidia.com>
Tested-by: mobile promotions <svcmobile_promotions@nvidia.com>