### PR TITLE
Resolve ACPI boot issues on AGX Orin

### DIFF
--- a/Platform/NVIDIA/NVIDIA.common.dsc.inc
+++ b/Platform/NVIDIA/NVIDIA.common.dsc.inc
@@ -931,6 +931,10 @@ gEfiSecurityPkgTokenSpaceGuid.PcdSingleBootApplicationGuid|{ GUID("cbf481fb-b373
   gNVIDIATokenSpaceGuid.PcdL4TConfigurationSupport|TRUE
 !endif
 
+!ifdef CONFIG_NVIDIA_DISPLAY
+  gNVIDIATokenSpaceGuid.PcdNvGopSupported|TRUE
+!endif
+
   # SBSA Watchdog - always override the ArmPkg.dec values
   gArmTokenSpaceGuid.PcdGenericWatchdogControlBase|$(CONFIG_ARM_WATCHDOG_CONTROL_BASE)
   gArmTokenSpaceGuid.PcdGenericWatchdogRefreshBase|$(CONFIG_ARM_WATCHDOG_REFRESH_BASE)

--- a/Silicon/NVIDIA/Drivers/AcpiDtbSsdtGenerator/AcpiDtbSsdtGenerator.c
+++ b/Silicon/NVIDIA/Drivers/AcpiDtbSsdtGenerator/AcpiDtbSsdtGenerator.c
@@ -340,7 +340,7 @@ AcpiProtocolReady (
 
   Status = gBS->LocateProtocol (&gEfiAcpiTableProtocolGuid, NULL, (VOID **)&AcpiTableProtocol);
   if (EFI_ERROR (Status)) {
-    goto Cleanup;
+    return;
   }
 
   gBS->CloseEvent (Event);

--- a/Silicon/NVIDIA/Drivers/NvidiaConfigDxe/NvidiaConfigDxe.c
+++ b/Silicon/NVIDIA/Drivers/NvidiaConfigDxe/NvidiaConfigDxe.c
@@ -1748,6 +1748,10 @@ InitializeSettings (
   VOID                                  *HobPointer;
   BOOLEAN                               DiscardVariableOverrides;
   CHAR16                                ProductInfoVariableName[] = L"ProductInfo";
+  BOOLEAN                               AcpiMode;
+  VOID                                  *Table;
+
+  AcpiMode = !EFI_ERROR (EfiGetSystemConfigurationTable (&gEfiAcpiTableGuid, &Table));
 
   // Initialize PCIe Form Settings
   PcdSet8S (PcdPcieResourceConfigNeeded, PcdGet8 (PcdPcieResourceConfigNeeded));
@@ -1876,12 +1880,13 @@ InitializeSettings (
     mOpRomDisMask = 0;
   }
 
-  mHiiControlSettings.L4TSupported         = PcdGetBool (PcdL4TConfigurationSupport);
-  mHiiControlSettings.QuickBootSupported   = FeaturePcdGet (PcdQuickBootSupported);
-  mHiiControlSettings.DebugMenuSupported   = FeaturePcdGet (PcdDebugMenuSupport);
-  mHiiControlSettings.RedfishSupported     = FeaturePcdGet (PcdRedfishSupported);
-  mHiiControlSettings.TpmPresent           = PcdGetBool (PcdTpmPresent);
-  mHiiControlSettings.MemoryTestsSupported = PcdGetBool (PcdMemoryTestsSupported);
+  mHiiControlSettings.L4TSupported                     = PcdGetBool (PcdL4TConfigurationSupport);
+  mHiiControlSettings.QuickBootSupported               = FeaturePcdGet (PcdQuickBootSupported);
+  mHiiControlSettings.DebugMenuSupported               = FeaturePcdGet (PcdDebugMenuSupport);
+  mHiiControlSettings.RedfishSupported                 = FeaturePcdGet (PcdRedfishSupported);
+  mHiiControlSettings.TpmPresent                       = PcdGetBool (PcdTpmPresent);
+  mHiiControlSettings.MemoryTestsSupported             = PcdGetBool (PcdMemoryTestsSupported);
+  mHiiControlSettings.NvDisplayHandoffControlSupported = PcdGetBool (PcdNvGopSupported) && !AcpiMode;
 
   HobPointer = GetFirstGuidHob (&gNVIDIATH500MB1DataGuid);
   if (HobPointer != NULL) {

--- a/Silicon/NVIDIA/Drivers/NvidiaConfigDxe/NvidiaConfigDxe.inf
+++ b/Silicon/NVIDIA/Drivers/NvidiaConfigDxe/NvidiaConfigDxe.inf
@@ -99,6 +99,7 @@
   gNVIDIATokenSpaceGuid.PcdBoardRecoveryBoot
   gNVIDIATokenSpaceGuid.PcdSocDisplayHandoffMode
   gNVIDIATokenSpaceGuid.PcdServerPowerControlSetting
+  gNVIDIATokenSpaceGuid.PcdNvGopSupported
 
 [Depex]
   gEfiVariableArchProtocolGuid        AND

--- a/Silicon/NVIDIA/Drivers/NvidiaConfigDxe/NvidiaConfigHii.h
+++ b/Silicon/NVIDIA/Drivers/NvidiaConfigDxe/NvidiaConfigHii.h
@@ -965,6 +965,7 @@ typedef struct {
   BOOLEAN    AdvertiseACS_1[MAX_PCIE];
   BOOLEAN    AdvertiseACS_2[MAX_PCIE];
   BOOLEAN    AdvertiseACS_3[MAX_PCIE];
+  BOOLEAN    NvDisplayHandoffControlSupported;
 } NVIDIA_CONFIG_HII_CONTROL;
 
 #define ADD_GOTO_SOCKET_FORM(socket)                                       \

--- a/Silicon/NVIDIA/Drivers/NvidiaConfigDxe/NvidiaConfigHii.vfr
+++ b/Silicon/NVIDIA/Drivers/NvidiaConfigDxe/NvidiaConfigHii.vfr
@@ -363,6 +363,7 @@ formset
       endcheckbox;
     endif;
 
+    suppressif ideqval NVIDIA_CONFIG_HII_CONTROL.NvDisplayHandoffControlSupported == 0;
     oneof varid = SocDisplayHandoffMode.Mode,
       questionid = KEY_SOC_DISPLAY_HANDOFF_MODE,
       prompt = STRING_TOKEN(STR_SOC_DISPLAY_HANDOFF_MODE_PROMPT),
@@ -372,6 +373,7 @@ formset
       option text = STRING_TOKEN(STR_ALWAYS), value = NVIDIA_SOC_DISPLAY_HANDOFF_MODE_ALWAYS, flags = 0;
       option text = STRING_TOKEN(STR_AUTO), value = NVIDIA_SOC_DISPLAY_HANDOFF_MODE_AUTO, flags = 0;
     endoneof;
+    endif;
   endform;
 
   //

--- a/Silicon/NVIDIA/NVIDIA.dec
+++ b/Silicon/NVIDIA/NVIDIA.dec
@@ -481,6 +481,9 @@
   ## The maximum number of boot options supported.
   gNVIDIATokenSpaceGuid.PcdMaximumBootOptions|0xFF|UINT16|0x0000012D
 
+  ## Use to determine if the internal nvidia GOP driver is supported.
+  gNVIDIATokenSpaceGuid.PcdNvGopSupported|FALSE|BOOLEAN|0x00000132
+
 [PcdsFeatureFlag]
 #OPTEE presence
   gNVIDIATokenSpaceGuid.PcdOpteePresent|FALSE|BOOLEAN|0x00000067


### PR DESCRIPTION
Resolve 2 issues with acpi boot on Orin.

1. Free before use issue that was reported in issue #116 in the AcpiSsdtDtbGenerator driver. This driver is refactored in later versions and this fix does not apply to later releases.
2. Backport leaving the internal display clocks on in ACPI boot from main branch.