### PR TITLE
Varintfixes r36.4.3 updates

### DIFF
--- a/Silicon/NVIDIA/Drivers/FvbNorFlashDxe/VarIntCheck.c
+++ b/Silicon/NVIDIA/Drivers/FvbNorFlashDxe/VarIntCheck.c
@@ -294,7 +294,7 @@ GetWriteOffset (
         *Offset     = BlockOffset;
         break;
       } else if (ReadBuf[0] == VAR_INT_VALID) {
-        ValidRecord = CurOffset;
+        ValidRecord = BlockOffset;
       }
 
       BlockOffset += This->MeasurementSize;
@@ -313,7 +313,7 @@ GetWriteOffset (
     if ((ValidRecord == 0) || (NumPartitionBlocks == 1)) {
       *Offset = This->PartitionByteOffset;
     } else {
-      CurBlock = (ValidRecord / This->PartitionByteOffset);
+      CurBlock = (ValidRecord / This->BlockSize);
       if (CurBlock == EndBlock) {
         *Offset = This->PartitionByteOffset;
       } else {

--- a/Silicon/NVIDIA/Include/Library/StandaloneMmOpteeDeviceMem.h
+++ b/Silicon/NVIDIA/Include/Library/StandaloneMmOpteeDeviceMem.h
@@ -1,6 +1,6 @@
 /** @file
 
-SPDX-FileCopyrightText: Copyright (c) 2022-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-FileCopyrightText: Copyright (c) 2022-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -335,6 +335,7 @@ struct _NVIDIA_VAR_INT_PROTOCOL {
   UINT64                         BlockSize;
   UINT8                          *CurMeasurement;
   UINT32                         MeasurementSize;
+  VOID                           *PartitionData;
 };
 
 #endif //STANDALONEMM_OPTEE_DEVICE_MEM_H

--- a/Silicon/NVIDIA/Library/NvVarIntLibrary/NvVarIntLibrary.c
+++ b/Silicon/NVIDIA/Library/NvVarIntLibrary/NvVarIntLibrary.c
@@ -5,7 +5,7 @@
   The APIs can be called during a variable update (before the FVB Write) or
   at bootup to measure the variables on flash.
 
-  SPDX-FileCopyrightText: Copyright (c) 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-FileCopyrightText: Copyright (c) 2024 - 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -362,8 +362,9 @@ MeasureSecureDbVars (
 
   PayloadPtr  = Data;
   PayloadSize = DataSize;
-  AppendWrite = FALSE;
+
   for (Index = 0; Index < (sizeof (SecureVars) / sizeof (SecureVars[0])); Index++) {
+    AppendWrite = FALSE;
     DEBUG ((
       DEBUG_INFO,
       "%a: First add %s VarName \n",


### PR DESCRIPTION
Bug Fixes to the VarStore Integrity module.

- Bug fix in the erase logic. Bug in LBA compute that impacts some code-paths.
- Bug fix in the logic to compute secure-boot hashes. This will manifest as a device crash if the secureboot keys are enrolled at runtime and the device is rebooted.