### PR TITLE
feat: Add Aquantia AQR113 PHY ID

### DIFF
--- a/Silicon/NVIDIA/Drivers/EqosDeviceDxe/PhyDxeUtil.c
+++ b/Silicon/NVIDIA/Drivers/EqosDeviceDxe/PhyDxeUtil.c
@@ -242,7 +242,8 @@ PhyConfig (
       PhyDriver->DetectLink   = PhyMicrelDetectLink;
       break;
 
-    case PHY_MGBE_OUI:
+    case PHY_AQR113C_OUI:
+    case PHY_AQR113_OUI:
       PhyDriver->Config       = PhyMGBEConfig;
       PhyDriver->StartAutoNeg = PhyMGBEStartAutoNeg;
       PhyDriver->CheckAutoNeg = PhyMGBECheckAutoNeg;

--- a/Silicon/NVIDIA/Drivers/EqosDeviceDxe/PhyMgbe.h
+++ b/Silicon/NVIDIA/Drivers/EqosDeviceDxe/PhyMgbe.h
@@ -9,7 +9,8 @@
 #ifndef _PHY_MGBE_H__
 #define _PHY_MGBE_H__
 
-#define PHY_MGBE_OUI  0x31C31C12
+#define PHY_AQR113C_OUI   0x31C31C12
+#define PHY_AQR113_OUI    0x31C31C42
 
 /*
  * @brief Configure MGBE PHY


### PR DESCRIPTION
- Add support for the Aquantia AQR113 PHY which is functionally identical
to the AQR113C used on the Nvidia AGX Orin Devkit.

- Rename "PHY_MGBE_OUI" to "PHY_AQR113C_OUI" for clarity.

Signed-off-by: Parker Newman <pnewman@connecttech.com>
