### PR TITLE
XsubcontrollerDxe: Fix build with gcc-15

### DIFF
--- a/Silicon/NVIDIA/Drivers/XusbControllerDxe/XusbControllerDxe.c
+++ b/Silicon/NVIDIA/Drivers/XusbControllerDxe/XusbControllerDxe.c
@@ -2287,6 +2287,8 @@ fail:
 STATIC
 VOID
 XudcCheckInterrupts (
+  IN        VOID  *p,
+  IN        VOID  *q
   )
 {
   XudcPollForEvent (0x10UL);


### PR DESCRIPTION
GCC-15 does not like the fact that the function signature does not match when it is passed as a function pointer

Fixes

XusbControllerDxe.c:2403:19: error: passing argument 3 of 'gBS->CreateEvent' from incompatible pointer type [-Wincompatible-pointer-types]
XusbControllerDxe.c:2403:19: note: expected 'EFI_EVENT_NOTIFY' {aka 'void (*)(void *, void *)'} but argument is of type 'void (*)(UINT32)' {aka 'void (*)(unsigned int)'}