### PR TITLE
fix: switch default value of PcdSocDisplayHandoffMode to Auto

### DIFF
--- a/Platform/NVIDIA/Kconfig
+++ b/Platform/NVIDIA/Kconfig
@@ -417,7 +417,7 @@ menu "Boot Options"
     help
       How to hand-off the SOC display.
 
-    default SOC_DISPLAY_HANDOFF_MODE_NEVER
+    default SOC_DISPLAY_HANDOFF_MODE_AUTO
 
     config SOC_DISPLAY_HANDOFF_MODE_NEVER
     bool "Never"


### PR DESCRIPTION
Enable the Auto mode of SOC display hand-off by default.


Reviewed-by: Ashish Singhal <ashishsingha@nvidia.com>
Reviewed-by: Jake Garver <jake@nvidia.com>
Tested-by: Jake Garver <jake@nvidia.com>