### PR TITLE
chore(github): Migrate to upload-artifact@v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -121,7 +121,7 @@ jobs:
           cd upload
           tar -czvf ../edk2-nvidia-${BUILDID}.tar.gz edk2-nvidia-${BUILDID}
       - name: Upload
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: package
           path: upload


### PR DESCRIPTION
upload-artifact@v3 is no longer allowed in github actions.