### PR TITLE
chore(github): Don't build StandaloneMmJetson yet

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -99,7 +99,6 @@ jobs:
           ([ -d edk2-redfish-client ] && edk2-nvidia/Platform/NVIDIA/Tegra/build.sh --init-defconfig edk2-nvidia/Platform/NVIDIA/Tegra/DefConfigs/t24x_datacenter.defconfig) || true
           edk2-nvidia/Platform/NVIDIA/StandaloneMmOptee/build.sh
           edk2-nvidia/Platform/NVIDIA/StandaloneMm/build.sh
-          edk2-nvidia/Platform/NVIDIA/StandaloneMmJetson/build.sh
           edk2-nvidia/Platform/NVIDIA/DeviceTree/build.sh
           edk2-nvidia/Platform/NVIDIA/L4TLauncher/build.sh
       - name: Package


### PR DESCRIPTION
This platform is not ready yet and shouldn't be built as part of the github CI.  It was mistakenly added.