### PR TITLE
feat: Add system fiber support

### DIFF
--- a/Platform/NVIDIA/NVIDIA.common.dsc.inc
+++ b/Platform/NVIDIA/NVIDIA.common.dsc.inc
@@ -441,6 +441,7 @@ CONFIG_LOGO_IMPLEMENTER = noimplementer.inf
   MemoryVerificationLib|Silicon/NVIDIA/Library/MemoryVerificationLib/MemoryVerificationLib.inf
 
   SystemContextLib|Silicon/NVIDIA/Library/SystemContextLib/SystemContextLib.inf
+  SystemFiberLib|Silicon/NVIDIA/Library/SystemFiberLib/SystemFiberLib.inf
   StatusRegLib|Silicon/NVIDIA/Library/StatusRegLib/StatusRegLib.inf
 
   OrderedCollectionLib|MdePkg/Library/BaseOrderedCollectionRedBlackTreeLib/BaseOrderedCollectionRedBlackTreeLib.inf

--- a/Silicon/NVIDIA/Include/Library/SystemFiberLib.h
+++ b/Silicon/NVIDIA/Include/Library/SystemFiberLib.h
@@ -1,0 +1,91 @@
+/** @file
+
+  SystemFiberLib - Library for system fiber operations
+
+  SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef SYSTEM_FIBER_LIB_H__
+#define SYSTEM_FIBER_LIB_H__
+
+#include <Uefi/UefiBaseType.h>
+
+typedef VOID (*SYSTEM_FIBER_ENTRY_POINT)(
+  VOID  *Context
+  );
+typedef VOID *SYSTEM_FIBER;
+
+/**
+  Creates a new fiber.
+  Fiber will not be started until ResumeSystemFiber is called.
+
+  @param[in] EntryPoint  Entry point of the fiber
+  @param[in] Context     Context of the fiber
+  @param[in] StackSize   Stack size of the fiber
+  @param[out] Fiber     Fiber object
+
+  @return EFI_SUCCESS if the fiber was created successfully
+  @return EFI_OUT_OF_RESOURCES if the fiber could not be created
+  @return EFI_INVALID_PARAMETER if the entry point is NULL
+*/
+EFI_STATUS
+EFIAPI
+CreateSystemFiber (
+  IN SYSTEM_FIBER_ENTRY_POINT  EntryPoint,
+  IN VOID                      *Context,
+  IN UINTN                     StackSize,
+  OUT SYSTEM_FIBER             *Fiber
+  );
+
+/**
+  Destroys a fiber
+  If the fiber is currently running, it will yield before being destroyed
+
+  @param[in] Fiber  Fiber object
+
+  @return EFI_SUCCESS if the fiber was destroyed successfully
+  @return EFI_INVALID_PARAMETER if the fiber is NULL
+*/
+EFI_STATUS
+EFIAPI
+DestroySystemFiber (
+  IN SYSTEM_FIBER  Fiber
+  );
+
+/**
+  Resumes a fiber
+  Will not return until the fiber yields.
+
+  @param[in] Fiber  Fiber object
+
+  @return EFI_SUCCESS if the fiber was resumed successfully
+  @return EFI_INVALID_PARAMETER if the fiber is NULL
+  @return EFI_ALREADY_STARTED if the fiber is already running
+  @return EFI_ABORTED if the fiber is marked as destroyed
+*/
+EFI_STATUS
+EFIAPI
+ResumeSystemFiber (
+  IN SYSTEM_FIBER  Fiber
+  );
+
+/**
+  Yields the current fiber.
+  This function will return to the caller of ResumeSystemFiber.
+
+  @param[in] Fiber  Fiber object
+
+  @return EFI_SUCCESS if the fiber was yielded successfully
+  @return EFI_INVALID_PARAMETER if the fiber is NULL
+  @return EFI_NOT_STARTED if the fiber is not running
+*/
+EFI_STATUS
+EFIAPI
+YieldSystemFiber (
+  IN SYSTEM_FIBER  Fiber
+  );
+
+#endif

--- a/Silicon/NVIDIA/Library/DeviceDiscoveryDriverLib/DeviceDiscoveryDriverLib.inf
+++ b/Silicon/NVIDIA/Library/DeviceDiscoveryDriverLib/DeviceDiscoveryDriverLib.inf
@@ -2,7 +2,7 @@
 #
 #  Device discovery driver library
 #
-#  SPDX-FileCopyrightText: Copyright (c) 2018-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#  SPDX-FileCopyrightText: Copyright (c) 2018-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
@@ -37,7 +37,7 @@
   IoLib
   DeviceDiscoveryLib
   DeviceTreeHelperLib
-  SystemContextLib
+  SystemFiberLib
 
 [Protocols]
   gEdkiiNonDiscoverableDeviceProtocolGuid

--- a/Silicon/NVIDIA/Library/DeviceDiscoveryDriverLib/DeviceDiscoveryDriverLibPrivate.h
+++ b/Silicon/NVIDIA/Library/DeviceDiscoveryDriverLib/DeviceDiscoveryDriverLibPrivate.h
@@ -2,7 +2,7 @@
 
   Device Discovery Driver Library private structures
 
-  SPDX-FileCopyrightText: Copyright (c) 2018-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-FileCopyrightText: Copyright (c) 2018-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -14,6 +14,7 @@
 #include <PiDxe.h>
 #include <Protocol/ArmScmiClock2Protocol.h>
 #include <Protocol/ClockParents.h>
+#include <Library/SystemFiberLib.h>
 
 extern SCMI_CLOCK2_PROTOCOL           *gScmiClockProtocol;
 extern NVIDIA_CLOCK_PARENTS_PROTOCOL  *gClockParentsProtocol;
@@ -27,7 +28,7 @@ typedef struct {
 typedef struct {
   EFI_PHYSICAL_ADDRESS                   StackBase;
   EFI_EVENT                              Timer;
-  EFI_SYSTEM_CONTEXT_AARCH64             Context;
+  SYSTEM_FIBER                           Fiber;
   EFI_HANDLE                             DriverHandle;
   EFI_HANDLE                             Controller;
   IN NVIDIA_DEVICE_TREE_NODE_PROTOCOL    *Node;

--- a/Silicon/NVIDIA/Library/SystemFiberLib/AArch64/SystemFiberLibAArch64.c
+++ b/Silicon/NVIDIA/Library/SystemFiberLib/AArch64/SystemFiberLibAArch64.c
@@ -1,0 +1,46 @@
+/** @file
+
+  SystemFiberLibPrivate - AArch64 functions for system fiber operations
+
+  SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "SystemFiberLibPrivate.h"
+#include <Library/BaseMemoryLib.h>
+#include <Library/DebugLib.h>
+
+/**
+  Initialze SystemContext */
+EFI_STATUS
+EFIAPI
+InitializeSystemContext (
+  IN OUT EFI_SYSTEM_CONTEXT  *SystemContext,
+  SYSTEM_FIBER_ENTRY_POINT   EntryPoint,
+  VOID                       *Context,
+  UINT8                      *Stack,
+  UINTN                      StackSize
+  )
+{
+  EFI_SYSTEM_CONTEXT          CurrentSystemContext;
+  EFI_SYSTEM_CONTEXT_AARCH64  CurrentSystemContextAArch64;
+
+  CurrentSystemContext.SystemContextAArch64 = &CurrentSystemContextAArch64;
+
+  ZeroMem (SystemContext->SystemContextAArch64, sizeof (EFI_SYSTEM_CONTEXT_AARCH64));
+
+  GetSystemContext (CurrentSystemContext);
+  SystemContext->SystemContextAArch64->ELR  = CurrentSystemContextAArch64.ELR;
+  SystemContext->SystemContextAArch64->SPSR = CurrentSystemContextAArch64.SPSR;
+  SystemContext->SystemContextAArch64->FPSR = CurrentSystemContextAArch64.FPSR;
+  SystemContext->SystemContextAArch64->ESR  = CurrentSystemContextAArch64.ESR;
+  SystemContext->SystemContextAArch64->FAR  = CurrentSystemContextAArch64.FAR;
+
+  SystemContext->SystemContextAArch64->LR = (UINT64)EntryPoint;
+  SystemContext->SystemContextAArch64->SP = (UINT64)Stack + StackSize;
+  SystemContext->SystemContextAArch64->X0 = (UINT64)Context;
+
+  return EFI_SUCCESS;
+}

--- a/Silicon/NVIDIA/Library/SystemFiberLib/SystemFiberLib.c
+++ b/Silicon/NVIDIA/Library/SystemFiberLib/SystemFiberLib.c
@@ -1,0 +1,283 @@
+/** @file
+
+  SystemFiberLib - Library for system fiber operations
+
+  SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "SystemFiberLibPrivate.h"
+
+#include <Library/DebugLib.h>
+#include <Library/MemoryAllocationLib.h>
+
+/**
+  Free internal memory resources
+
+  @param[in] FiberContext  Fiber context
+ */
+STATIC
+VOID
+EFIAPI
+FreeInternalResources (
+  IN SYSTEM_FIBER_CONTEXT  *FiberContext
+  )
+{
+  if (FiberContext->Stack != NULL) {
+    FreePages (FiberContext->Stack, EFI_SIZE_TO_PAGES (FiberContext->StackSize));
+    FiberContext->Stack = NULL;
+  }
+
+  if (FiberContext->SystemContext.SystemContextAArch64 != NULL) {
+    FreePool (FiberContext->SystemContext.SystemContextAArch64);
+    FiberContext->SystemContext.SystemContextAArch64 = NULL;
+  }
+
+  if (FiberContext->ParentSystemContext.SystemContextAArch64 != NULL) {
+    FreePool (FiberContext->ParentSystemContext.SystemContextAArch64);
+    FiberContext->ParentSystemContext.SystemContextAArch64 = NULL;
+  }
+}
+
+/**
+  System Fiber start function
+  This function is called when the fiber is started
+  and will call the entry point of the fiber
+
+  @param[in] Fiber  Fiber object
+*/
+STATIC
+VOID
+EFIAPI
+SystemFiberStart (
+  IN SYSTEM_FIBER  Fiber
+  )
+{
+  SYSTEM_FIBER_CONTEXT  *FiberContext;
+
+  FiberContext = (SYSTEM_FIBER_CONTEXT *)Fiber;
+
+  FiberContext->EntryPoint (FiberContext->Context);
+  DestroySystemFiber (Fiber);
+
+  // Should never get here
+  ASSERT (FALSE);
+  CpuDeadLoop ();
+}
+
+/**
+  Creates a new fiber
+
+  @param[in] EntryPoint  Entry point of the fiber
+  @param[in] Context     Context of the fiber
+  @param[in] StackSize   Stack size of the fiber
+  @param[out] Fiber     Fiber object
+
+  @return EFI_SUCCESS if the fiber was created successfully
+  @return EFI_OUT_OF_RESOURCES if the fiber could not be created
+  @return EFI_INVALID_PARAMETER if the entry point is NULL
+*/
+EFI_STATUS
+EFIAPI
+CreateSystemFiber (
+  IN SYSTEM_FIBER_ENTRY_POINT  EntryPoint,
+  IN VOID                      *Context,
+  IN UINTN                     StackSize,
+  OUT SYSTEM_FIBER             *Fiber
+  )
+{
+  EFI_STATUS            Status;
+  SYSTEM_FIBER_CONTEXT  *FiberContext;
+
+  FiberContext = NULL;
+
+  if (Fiber == NULL) {
+    Status = EFI_INVALID_PARAMETER;
+    goto ExitHandler;
+  }
+
+  if (EntryPoint == NULL) {
+    Status = EFI_INVALID_PARAMETER;
+    goto ExitHandler;
+  }
+
+  if (StackSize < MIN_STACK_SIZE) {
+    Status = EFI_INVALID_PARAMETER;
+    goto ExitHandler;
+  }
+
+  FiberContext = (SYSTEM_FIBER_CONTEXT *)AllocateZeroPool (sizeof (SYSTEM_FIBER_CONTEXT));
+  if (FiberContext == NULL) {
+    Status = EFI_OUT_OF_RESOURCES;
+    goto ExitHandler;
+  }
+
+  FiberContext->EntryPoint = EntryPoint;
+  FiberContext->Context    = Context;
+  FiberContext->StackSize  = StackSize;
+  FiberContext->Stack      = AllocatePages (EFI_SIZE_TO_PAGES (StackSize));
+  if (FiberContext->Stack == NULL) {
+    Status = EFI_OUT_OF_RESOURCES;
+    DEBUG ((DEBUG_ERROR, "%a: AllocatePages Stack failed\n", __func__));
+    goto ExitHandler;
+  }
+
+  // Allocate memory for any system context, using AArch64 as placeholder
+  FiberContext->SystemContext.SystemContextAArch64 = (EFI_SYSTEM_CONTEXT_AARCH64 *)AllocateZeroPool (MAX_SYSTEM_CONTEXT_SIZE);
+  if (FiberContext->SystemContext.SystemContextAArch64 == NULL) {
+    Status = EFI_OUT_OF_RESOURCES;
+    DEBUG ((DEBUG_ERROR, "%a: AllocateZeroPool SystemContext failed\n", __func__));
+    goto ExitHandler;
+  }
+
+  // Architecture specific initialization
+  Status = InitializeSystemContext (&FiberContext->SystemContext, SystemFiberStart, FiberContext, FiberContext->Stack, StackSize);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a: InitializeSystemContext failed\n", __func__));
+    goto ExitHandler;
+  }
+
+  // Allocate memory for the parent system context
+  FiberContext->ParentSystemContext.SystemContextAArch64 = (EFI_SYSTEM_CONTEXT_AARCH64 *)AllocateZeroPool (MAX_SYSTEM_CONTEXT_SIZE);
+  if (FiberContext->ParentSystemContext.SystemContextAArch64 == NULL) {
+    Status = EFI_OUT_OF_RESOURCES;
+    DEBUG ((DEBUG_ERROR, "%a: AllocateZeroPool ParentSystemContext failed\n", __func__));
+    goto ExitHandler;
+  }
+
+  FiberContext->IsRunning = FALSE;
+
+  *Fiber = FiberContext;
+
+ExitHandler:
+  if (EFI_ERROR (Status)) {
+    if (FiberContext != NULL) {
+      FreeInternalResources (FiberContext);
+      FreePool (FiberContext);
+    }
+  }
+
+  return Status;
+}
+
+/**
+  Destroys a fiber
+  If the fiber is currently running, it will be yield before being destroyed
+
+  @param[in] Fiber  Fiber object
+
+  @return EFI_SUCCESS if the fiber was destroyed successfully
+  @return EFI_INVALID_PARAMETER if the fiber is NULL
+*/
+EFI_STATUS
+EFIAPI
+DestroySystemFiber (
+  IN SYSTEM_FIBER  Fiber
+  )
+{
+  EFI_STATUS            Status;
+  SYSTEM_FIBER_CONTEXT  *FiberContext;
+
+  if (Fiber == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  FiberContext = (SYSTEM_FIBER_CONTEXT *)Fiber;
+
+  // If the fiber is running, yield it before destroying it
+  FiberContext->IsDestroyed = TRUE;
+  if (FiberContext->IsRunning) {
+    // This will end up in ResumeSystemFiber call in other context and will never return
+    Status = YieldSystemFiber (Fiber);
+    // Should never get here
+    ASSERT (FALSE);
+    if (EFI_ERROR (Status)) {
+      return Status;
+    }
+  }
+
+  FreeInternalResources (FiberContext);
+  FreePool (FiberContext);
+
+  return EFI_SUCCESS;
+}
+
+/**
+  Resumes a fiber
+
+  @param[in] Fiber  Fiber object
+
+  @return EFI_SUCCESS if the fiber was resumed successfully
+  @return EFI_INVALID_PARAMETER if the fiber is NULL
+  @return EFI_ALREADY_STARTED if the fiber is already running
+  @return EFI_ABORTED if the fiber is marked as destroyed
+*/
+EFI_STATUS
+EFIAPI
+ResumeSystemFiber (
+  IN SYSTEM_FIBER  Fiber
+  )
+{
+  EFI_STATUS            Status;
+  SYSTEM_FIBER_CONTEXT  *FiberContext;
+
+  if (Fiber == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  FiberContext = (SYSTEM_FIBER_CONTEXT *)Fiber;
+
+  if (FiberContext->IsRunning) {
+    return EFI_ALREADY_STARTED;
+  }
+
+  if (FiberContext->IsDestroyed) {
+    return EFI_ABORTED;
+  }
+
+  FiberContext->IsRunning = TRUE;
+  Status                  = SwapSystemContext (FiberContext->ParentSystemContext, FiberContext->SystemContext);
+  // Free resources if the fiber is marked as destroyed, happens when the fiber exits it main function
+  // Have to do this here as opposed to the DestroySystemFiber function for running fibers
+  // as we need to yield the fiber before destroying it
+  if (FiberContext->IsDestroyed) {
+    FreeInternalResources (FiberContext);
+  }
+
+  return Status;
+}
+
+/**
+  Yields the current fiber
+
+  @param[in] Fiber  Fiber object
+
+  @return EFI_SUCCESS if the fiber was yielded successfully
+  @return EFI_INVALID_PARAMETER if the fiber is NULL
+  @return EFI_NOT_STARTED if the fiber is not running
+*/
+EFI_STATUS
+EFIAPI
+YieldSystemFiber (
+  IN SYSTEM_FIBER  Fiber
+  )
+{
+  EFI_STATUS            Status;
+  SYSTEM_FIBER_CONTEXT  *FiberContext;
+
+  if (Fiber == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  FiberContext = (SYSTEM_FIBER_CONTEXT *)Fiber;
+
+  if (!FiberContext->IsRunning) {
+    return EFI_NOT_STARTED;
+  }
+
+  FiberContext->IsRunning = FALSE;
+  Status                  = SwapSystemContext (FiberContext->SystemContext, FiberContext->ParentSystemContext);
+  return Status;
+}

--- a/Silicon/NVIDIA/Library/SystemFiberLib/SystemFiberLib.inf
+++ b/Silicon/NVIDIA/Library/SystemFiberLib/SystemFiberLib.inf
@@ -1,0 +1,33 @@
+#/** @file
+#
+#  SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION. All rights reserved.
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+#**/
+
+[Defines]
+  INF_VERSION                    = 1.29
+  BASE_NAME                      = SystemFiberLib
+  FILE_GUID                      = 26ea111e-dbc0-44ae-a4e9-e6b19d0d6810
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = SystemFiberLib
+
+
+[Sources]
+  SystemFiberLib.c
+
+[Sources.AARCH64]
+  AArch64/SystemFiberLibAArch64.c
+
+[LibraryClasses]
+  BaseLib
+  DebugLib
+  MemoryAllocationLib
+  SystemContextLib
+
+
+[Packages]
+  MdePkg/MdePkg.dec
+  Silicon/NVIDIA/NVIDIA.dec

--- a/Silicon/NVIDIA/Library/SystemFiberLib/SystemFiberLibPrivate.h
+++ b/Silicon/NVIDIA/Library/SystemFiberLib/SystemFiberLibPrivate.h
@@ -1,0 +1,56 @@
+/** @file
+
+  SystemFiberLib - Private header for system fiber operations
+
+  SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef __SYSTEM_FIBER_LIB_PRIVATE_H__
+#define __SYSTEM_FIBER_LIB_PRIVATE_H__
+
+#include <Base.h>
+#include <Library/BaseLib.h>
+#include <Library/SystemContextLib.h>
+#include <Library/SystemFiberLib.h>
+#include <Protocol/DebugSupport.h>
+
+#define MIN_STACK_SIZE  SIZE_4KB
+
+// Calculate the maximum size needed
+#define MAX_SYSTEM_CONTEXT_SIZE \
+  MAX(sizeof(EFI_SYSTEM_CONTEXT_IPF), \
+      MAX(sizeof(EFI_SYSTEM_CONTEXT_AARCH64), \
+          MAX(sizeof(EFI_SYSTEM_CONTEXT_X64), \
+              MAX(sizeof(EFI_SYSTEM_CONTEXT_RISCV64), \
+                  MAX(sizeof(EFI_SYSTEM_CONTEXT_LOONGARCH64), \
+                      MAX(sizeof(EFI_SYSTEM_CONTEXT_IA32), \
+                          MAX(sizeof(EFI_SYSTEM_CONTEXT_ARM), \
+                              sizeof(EFI_SYSTEM_CONTEXT_EBC))))))))
+
+typedef struct {
+  SYSTEM_FIBER_ENTRY_POINT    EntryPoint;
+  VOID                        *Context;
+  UINT8                       *Stack;
+  UINTN                       StackSize;
+  EFI_SYSTEM_CONTEXT          SystemContext;
+  EFI_SYSTEM_CONTEXT          ParentSystemContext;
+  BOOLEAN                     IsRunning;
+  BOOLEAN                     IsDestroyed;
+} SYSTEM_FIBER_CONTEXT;
+
+/**
+  Initialze SystemContext */
+EFI_STATUS
+EFIAPI
+InitializeSystemContext (
+  IN OUT EFI_SYSTEM_CONTEXT  *SystemContext,
+  SYSTEM_FIBER_ENTRY_POINT   EntryPoint,
+  VOID                       *Context,
+  UINT8                      *Stack,
+  UINTN                      StackSize
+  );
+
+#endif


### PR DESCRIPTION
Add support for system fiber API.
This provides a lightweight thread implementation
that can be used to suspend and resume execution
without requiring a full unwind of the stack.

This has no functional changes from the prior support but should allow for easier test implementation.