### PR TITLE
feat: Add Aquantia AQR113C_B1 OUI

### DIFF
--- a/Silicon/NVIDIA/Drivers/EqosDeviceDxe/PhyDxeUtil.c
+++ b/Silicon/NVIDIA/Drivers/EqosDeviceDxe/PhyDxeUtil.c
@@ -243,7 +243,8 @@ PhyConfig (
       PhyDriver->DetectLink   = PhyMicrelDetectLink;
       break;
 
-    case PHY_AQR113C_OUI:
+    case PHY_AQR113C_B0_OUI:
+    case PHY_AQR113C_B1_OUI:
     case PHY_AQR113_OUI:
       PhyDriver->Config       = PhyMGBEConfig;
       PhyDriver->StartAutoNeg = PhyMGBEStartAutoNeg;

--- a/Silicon/NVIDIA/Drivers/EqosDeviceDxe/PhyMgbe.h
+++ b/Silicon/NVIDIA/Drivers/EqosDeviceDxe/PhyMgbe.h
@@ -9,8 +9,9 @@
 #ifndef _PHY_MGBE_H__
 #define _PHY_MGBE_H__
 
-#define PHY_AQR113C_OUI  0x31C31C12
-#define PHY_AQR113_OUI   0x31C31C42
+#define PHY_AQR113C_B0_OUI  0x31C31C12
+#define PHY_AQR113C_B1_OUI  0x31C31C13
+#define PHY_AQR113_OUI      0x31C31C42
 
 /*
  * @brief Configure MGBE PHY


### PR DESCRIPTION
Add support for the Aquantia AQR113C B1 variant OUI which is functionally identical to the AQR113C B0 variant. This is discovered to be used on the t234-A01-1-Silicon Orin AGX Dev Kit.

Link: https://forums.developer.nvidia.com/t/orin-network-boot-not-working-on-some-units/342799